### PR TITLE
Spanish translation fixes

### DIFF
--- a/es_ES/LC_MESSAGES/blockSettings.po
+++ b/es_ES/LC_MESSAGES/blockSettings.po
@@ -1,59 +1,59 @@
-msgid "LOGIN_REQUIRED_TO_MANAGE_BLOCKS"
-msgstr "Es necesario que inicies sesión para poder editar los usuarios bloqueados."
+﻿msgid "LOGIN_REQUIRED_TO_MANAGE_BLOCKS"
+msgstr "Es necesario que inicies sesión para administrar los usuarios bloqueados."
 
 msgid "NO_USERS_BLOCKED"
 msgstr "No tienes usuarios bloqueados."
 
 msgid "BLOCKED_USERS"
-msgstr "Usuarios Bloqueados."
+msgstr "Usuarios bloqueados"
 
 msgid "BLOCK_USER"
 msgstr "Bloquear usuario."
 
 msgid "COMMENT_BLOCK_IS_MUTUAL"
-msgstr "Una vez que hayas bloqueado a este usuario no podrás comentar en sus flipnotes, ni él en las tuyas."
+msgstr "Una vez que hayas bloqueado a este usuario, no podrás comentar en sus Flipnotes, ni este en las tuyas."
 
 msgid "USER_HAS_BEEN_BLOCKED"
 msgstr "Este usuario ha sido bloqueado."
 
 msgid "IF_YOU_WISH_TO_UNBLOCK"
-msgstr "Si desea desbloquear a este usuario, deberá desbloquearlo visitando tu Sitio del Creador y abriendo el menú de usuarios bloqueados."
+msgstr "Si deseas desbloquear a este usuario, deberás desbloquearlo en tu Sala del Creador, abriendo el menú de usuarios bloqueados."
 
 msgid "CONFIRM_BLOCK"
 msgstr "Confirmar bloqueo."
 
 msgid "USER_ALREADY_BLOCKED"
-msgstr "Ya ha bloqueado a este usuario, deberá desbloquearlo en el menú de configuración en tu Sitio del Creador, pero deberás esperar 24 horas antes de bloquearlo de nuevo."
+msgstr "Ya has bloqueado a este usuario. Puedes desbloquearlo al menú de configuración en tu Sala del Creador, pero deberás esperar 24 horas antes de bloquearlo de nuevo."
 
 msgid "ONE_DAY_WAIT_BEFORE_REBLOCK_FORMAT"
 msgstr "Ya has bloqueado a este usuario recientemente. No puedes bloquearlo hasta %s"
 
 msgid "UNBLOCK"
-msgstr "Desbloquear."
+msgstr "Desbloquear"
 
 msgid "LOGIN_REQUIRED"
 msgstr "Necesitas iniciar sesión para realizar esta acción."
 
 msgid "TAP_BACK_TO_RETURN"
-msgstr "Presiona para regresar a tu Sitio del Creador."
+msgstr "Presiona para regresar a tu Sala del Creador."
 
 msgid "UNBLOCK_USER"
-msgstr "Desbloquear usuario."
+msgstr "Desbloquear usuario"
 
 msgid "CANNOT_UNBLOCK_NONBLOCKED_USER"
-msgstr "No puedes desbloquear este usuario porque no lo tienes bloqueado."
+msgstr "No puedes desbloquear a este usuario porque no está bloqueado."
 
 msgid "USER_HAS_BEEN_UNBLOCKED"
 msgstr "Has desbloqueado a este usuario."
 
 msgid "COMMENTING_ENABLED_AFTER_UNBLOCK"
-msgstr "Despues de haber desbloqueado a este usuario, podrán comentar en las flipnotes de cada uno de nuevo, a menos de que te tenga bloqueado también."
+msgstr "Después de haber desbloqueado a este usuario, podrás comentar en sus Flipnotes nuevamente, a menos de que este también te haya bloqueado."
 
 msgid "UNBLOCK_WARNING_ONE_DAY_THRESHOLD"
-msgstr "Si ha bloqueado al usuario, debe esperar 24 horas antes de poder bloquearlo de nuevo."
+msgstr "Si has bloqueado al usuario, debes esperar 24 horas antes de poder bloquearlo de nuevo."
 
 msgid "CONFIRM_UNBLOCK"
-msgstr "Confirmar desbloqueo."
+msgstr "Confirmar desbloqueo"
 
 msgid "RECENTLY_UNBLOCKED_ONE_DAY_THRESHOLD"
-msgstr "Recientemente ya ha desbloqueado a este usuario, debe esperar 24 horas desde la hora que lo desbloqueo antes de que pueda bloquearlo de nuevo."
+msgstr "Ya has desbloqueado a este usuario recientemente. Debes esperar 24 horas desde la hora que lo desbloqueaste antes de lo que puedas bloquear de nuevo."

--- a/es_ES/LC_MESSAGES/browseChannel.po
+++ b/es_ES/LC_MESSAGES/browseChannel.po
@@ -1,21 +1,21 @@
 msgid "UPPERTITLE"
-msgstr "Canal de Navegación."
+msgstr "Canal de Navegación"
 
 msgid "POST_FLIPNOTE"
-msgstr "Publicar Flipnote."
+msgstr "Publicar Flipnote"
 
 msgid "NEXT"
-msgstr "Siguiente."
+msgstr "Siguiente"
 
 msgid "PREV"
-msgstr "Anterior."
+msgstr "Anterior"
 
 msgid "PAGE"
-msgstr "Página."
+msgstr "Página"
 
 msgid "PAGE_COUNTER_FORMAT"
 msgstr "%d de %d"
 
 msgid "SPINOFFS"
-msgstr "Spin-offs."
+msgstr "Spin-offs"
 

--- a/es_ES/LC_MESSAGES/browseFlipnotes.po
+++ b/es_ES/LC_MESSAGES/browseFlipnotes.po
@@ -20,13 +20,13 @@ msgid "HEADER_ROLEPLAYS"
 msgstr "Juegos de Rol"
 
 msgid "HEADER_BROWSE_FLIPNOTES"
-msgstr "Navegar entre las Flipnotes"
+msgstr "Ver Flipnotes"
 
 msgid "HEADER_FEATURED_FLIPNOTES"
 msgstr "Flipnotes Destacadas"
 
 msgid "HEADER_RANDOM_FLIPNOTES"
-msgstr "Random Flipnotes"
+msgstr "Flipnotes al azar"
 
 msgid "HEADER_PAGE"
 msgstr "Página"
@@ -59,5 +59,5 @@ msgid "CATEGORY_featured"
 msgstr "Flipnotes Destacadas"
 
 msgid "CATEGORY_random"
-msgstr "@Random Flipnotes"
+msgstr "Flipnotes al azar"
 

--- a/es_ES/LC_MESSAGES/channelCategories.po
+++ b/es_ES/LC_MESSAGES/channelCategories.po
@@ -23,4 +23,4 @@ msgid "PERSONAL"
 msgstr "Personal"
 
 msgid "WEEKLY_TOPICS"
-msgstr "Temas de la semana"
+msgstr "Temas semanales"

--- a/es_ES/LC_MESSAGES/channelDetails.po
+++ b/es_ES/LC_MESSAGES/channelDetails.po
@@ -20,13 +20,13 @@ msgid "FLIPNOTE_POST_FAIL_USER_BANNED"
 msgstr "Tus interacciones en Sudomemo han sido restringidas."
 
 msgid "FLIPNOTE_POST_FAILED"
-msgstr "Ha ocurrido un error al publicar esta Flipnote. Intenta de nuevo en unos momentos."
+msgstr "Ha ocurrido un error al publicar esta Flipnote. Intenta de nuevo más tarde."
 
 msgid "DUPLICATE_FLIPNOTE_FAILED"
-msgstr "Esta flipnote ya ha sido publicada. Edítala para poder publicarla."
+msgstr "Esta Flipnote ya ha sido publicada. Edítala para poder publicarla."
 
 msgid "FLIPNOTE_DATA_CORRUPTED"
-msgstr "Los datos de esta Flipnote estan corruptos. Intenta de nuevo en unos momentos."
+msgstr "Los datos de esta Flipnote estan corruptos. Intenta de nuevo más tarde."
 
 msgid "NO_BLANK_FLIPNOTES_ALLOWED"
 msgstr "No se permite publicar una Flipnote vacía."
@@ -35,4 +35,4 @@ msgid "CONFIRM_EMAIL_BEFORE_POSTING"
 msgstr "Por favor, confirma tu correo antes de publicar."
 
 msgid "NO_POSTS_WHILE_MUTED"
-msgstr "You may not post while you are muted."
+msgstr "No puedes publicar una Flipnote si estás silenciado."

--- a/es_ES/LC_MESSAGES/channelList.po
+++ b/es_ES/LC_MESSAGES/channelList.po
@@ -2,7 +2,7 @@ msgid "UPPERTITLE"
 msgstr "Canales"
 
 msgid "UPPERSUBBOTTOM"
-msgstr "Por favor ¡escoge un canal!"
+msgstr "¡Escoge un canal!"
 
 msgid "NEXT"
 msgstr "Siguiente"

--- a/es_ES/LC_MESSAGES/chatrooms.po
+++ b/es_ES/LC_MESSAGES/chatrooms.po
@@ -1,5 +1,5 @@
 msgid "NO_COMMENTS_YET"
-msgstr "Ningún comentario ha sido publicado aún."
+msgstr "Aún no hay mensajes."
 
 msgid "HEADER_COMMENTS"
 msgstr "Comentarios"
@@ -17,25 +17,25 @@ msgid "HEADER_REFRESH"
 msgstr "Actualizar"
 
 msgid "LOGIN_REQUIRED_TO_POST_CHAT_MESSAGE"
-msgstr "Debes iniciar sesión para publicar un comentario."
+msgstr "Debes iniciar sesión para enviar un mensaje."
 
 msgid "CHAT_REPLY_FAILED"
-msgstr "Ha ocurrido un error al publicar el comentario. Prueba de nuevo en un momento."
+msgstr "Ha ocurrido un error al enviar el mensaje. Inténtalo de nuevo más tarde."
 
 msgid "NO_BLANK_MESSAGES_ALLOWED"
-msgstr "¡No puedes publicar un comentario vacio!"
+msgstr "¡No puedes enviar un mensaje vacío!"
 
 msgid "FLIPNOTE_DATA_CORRUPTED"
-msgstr "Los datos de esta Flipnote estan corruptos. Prueba de nuevo en un momento."
+msgstr "Los datos de esta Flipnote están corruptos. Inténtalo de nuevo más tarde."
 
 msgid "NO_CHAT_MESSAGES_WHILE_MUTED"
-msgstr "Usted ha sido muteado. No podrá publicar comentarios mientras esté muteado."
+msgstr "Has sido silenciado. No puedes enviar mensajes."
 
 msgid "DUPLICATE_COMMENT_FAILED"
 msgstr "Este comentario ya ha sido publicado en Sudomemo."
 
 msgid "COMMENT_FAILED_USER_BANNED"
-msgstr "Tu interacción al publicar un comentario ha sido restringida de Sudomemo."
+msgstr "Has sido restringido de enviar mensajes en Sudomemo."
 
 msgid "CONFIRM_EMAIL_BEFORE_POSTING"
 msgstr "Por favor, confirma tu correo antes de publicar."

--- a/es_ES/LC_MESSAGES/commentDetails.po
+++ b/es_ES/LC_MESSAGES/commentDetails.po
@@ -1,8 +1,8 @@
-msgid "COMMENT_DETAILS"
-msgstr "Detalles de los comentarios"
+﻿msgid "COMMENT_DETAILS"
+msgstr "Detalles del comentario"
 
 msgid "MESSAGE_DETAILS"
-msgstr "Detalles de los mensajes"
+msgstr "Detalles del mensaje"
 
 msgid "AUTHOR"
 msgstr "Autor"
@@ -29,13 +29,13 @@ msgid "CHAT_COMMENT_ID"
 msgstr "ID del comentario del chat"
 
 msgid "TIMESTAMP"
-msgstr "Timestamp"
+msgstr "Fecha y hora"
 
 msgid "POSTED_TO"
-msgstr "Publicado a"
+msgstr "Publicado en"
 
 msgid "PRIVATE_CONVERSATION"
-msgstr "Conversación Privada"
+msgstr "Conversación privada"
 
 msgid "REPORT_CONTENT"
 msgstr "Reportar contenido"

--- a/es_ES/LC_MESSAGES/commonEmailStrings.po
+++ b/es_ES/LC_MESSAGES/commonEmailStrings.po
@@ -1,9 +1,9 @@
 msgid "TEXT_CHANGE_SETTINGS_PROMPT"
-msgstr "Want to adjust the emails you get from Sudomemo?"
+msgstr "¿Quieres ajustar qué tipo de correo recibes desde Sudomemo?"
 
 msgid "TEXT_HOW_TO_CHANGE_SETTINGS_DSI"
-msgstr "You can easily update them by visiting your Creator's Room on Sudomemo and selecting <strong>Mail Settings</strong>."
+msgstr "Ve a tu Sala del Creador en Sudomemo desde tu Nintendo DSi, y selecciona <strong>Ajustes de correo</strong>."
 
 msgid "TEXT_WEB_SETTINGS_CHANGE_FORMAT"
-msgstr "Or, you can turn off these kinds of emails by clicking <a target=\"_blank\" href=\"%s\"><strong>here</strong></a>."
+msgstr "O también puedes desactivarlos haciendo clic <a target=\"_blank\" href=\"%s\"><strong>aquí</strong></a>."
 

--- a/es_ES/LC_MESSAGES/creatorsRoom.po
+++ b/es_ES/LC_MESSAGES/creatorsRoom.po
@@ -41,7 +41,7 @@ msgid "NOT_USABLE"
 msgstr "No Usable"
 
 msgid "SUDOMEMO_THEATRE_URL"
-msgstr "Link de Sudomemo Theatre"
+msgstr "Enlace de Sudomemo Theatre"
 
 msgid "FLIPNOTE_STUDIO_ID"
 msgstr "ID de Flipnote Studio"
@@ -53,7 +53,7 @@ msgid "ADMIN_ACCT_GOOD_STANDING"
 msgstr "En buen estado"
 
 msgid "ADMIN_ACCT_BANNED"
-msgstr "Baneado"
+msgstr "Restringido"
 
 msgid "ADMIN_ACCT_BLOCKED"
 msgstr "Bloqueado"
@@ -113,16 +113,16 @@ msgid "THEMETEST_SET_THEME"
 msgstr "Establecer tema"
 
 msgid "THEMETEST_NOTICE"
-msgstr "Noticia"
+msgstr "Aviso"
 
 msgid "THEMETEST_OK"
-msgstr "Okay"
+msgstr "Aceptar"
 
 msgid "THEMETEST_ERROR"
 msgstr "Error"
 
 msgid "THEMETEST_NOTICE_2"
-msgstr "Noticia #2"
+msgstr "Aviso N°2"
 
 msgid "THEMETEST_ACTIVE_TAB"
 msgstr "Pestaña activa"
@@ -137,46 +137,46 @@ msgid "CREATORS_ROOM"
 msgstr "Sala del Creador"
 
 msgid "THEME_ERROR_THEME_NOT_OWNED"
-msgstr "¡Caracoles! No tienes ese tema."
+msgstr "¡Vaya! No tienes ese tema..."
 
 msgid "THEME_SUCCESSFULLY_SET"
-msgstr "¡Tema exitosamente establecido!"
+msgstr "¡Tema establecido!"
 
 msgid "BLOCKED_USERS"
 msgstr "Usuarios bloqueados"
 
 msgid "VIEW"
-msgstr "Vista"
+msgstr "Ver"
 
 msgid "FAN_COUNT_FORMAT"
 msgstr "Fans: %s"
 
 msgid "HEADER_LANGUAGE"
-msgstr "Lenguaje"
+msgstr "Idioma"
 
 msgid "HEADER_MAIL_SETTINGS"
 msgstr "Ajustes de correo"
 
 msgid "HEADER_EDIT_BIOGRAPHY"
-msgstr "Edit Biography"
+msgstr "Editar biografía"
 
 msgid "SET_BIO_INSTRUCTIONS"
-msgstr "Enter your profile biography below. This will be displayed on Sudomemo and Sudomemo Theatre."
+msgstr "Escribe una pequeña introducción aquí. Será visible tanto en Sudomemo como en Sudomemo Theatre."
 
 msgid "ENTER_BIO"
-msgstr "Enter Bio..."
+msgstr "Escribir biografía..."
 
 msgid "101_CHARACTER_LIMIT_BIO"
-msgstr "Your biography is limited to 101 characters."
+msgstr "Tu biografía está limitada a 101 caracteres."
 
 msgid "LEAVE_BLANK_TO_RESET_BIO"
-msgstr "To clear your biography, leave the form blank when submitting."
+msgstr "Para borrar tu biografía, deja el cuadro en blanco antes de confirmar."
 
 msgid "CURRENT_BIO"
-msgstr "Current Bio:"
+msgstr "Biografía actual:"
  
 msgid "FOLLOW_LIMIT_EXCEEDED_FORMAT"
-msgstr "You can't follow more than %d users."
+msgstr "No puedes seguir a más de %d usuarios."
 
 msgid "RANKING"
 msgstr "Ranking"

--- a/es_ES/LC_MESSAGES/detailsPage.po
+++ b/es_ES/LC_MESSAGES/detailsPage.po
@@ -1,5 +1,5 @@
 msgid "TIMESTAMP_FORMAT"
-msgstr "M d, Y H:i:s"
+msgstr "d M, Y H:i:s"
 
 msgid "FLIPNOTE_TITLE_FORMAT"
 msgstr "Flipnote de %s"
@@ -14,10 +14,10 @@ msgid "HEADER_THIS_FLIPNOTE_IS_A_SPINOFF"
 msgstr "Esta Flipnote es una Spin-off."
 
 msgid "HEADER_ORIGINAL_FLIPNOTE"
-msgstr "Ver la Flipnote original aquí."
+msgstr "Mira la Flipnote original aquí."
 
 msgid "HEADER_NO_STARBEGGING_STAR_LIMIT"
-msgstr "Para prevenir exceso de estrellas, las estrellas amarillas estan limitadas a diez por Flipnote."
+msgstr "Para prevenir un exceso de estrellas, las estrellas amarillas estan limitadas a diez por Flipnote."
 
 msgid "HEADER_CREATOR"
 msgstr "Creador"
@@ -74,35 +74,35 @@ msgid "SET_TITLE_INSTRUCTIONS"
 msgstr "Ingresa el nuevo título para tu Flipnote debajo."
 
 msgid "40_CHARACTER_LIMIT"
-msgstr "Tu título esta limitado a 40 caractéres de longitud."
+msgstr "Tu título esta limitado a 40 caracteres de longitud."
 
 msgid "LEAVE_BLANK_TO_RESET"
-msgstr "Para restablecer el título como predeterminado, deja el formulario en blanco a la hora de subirlo."
+msgstr "Para mantener el título predeterminado, deja el cuadro en blanco antes de confirmar."
 
 msgid "ENTER_TITLE"
 msgstr "Ingresar título..."
 
 msgid "HEADER_ADD_DESCRIPTION"
-msgstr "Add Description"
+msgstr "Añadir descripción"
 
 msgid "HEADER_DESCRIPTION"
-msgstr "Description"
+msgstr "Descripción"
 
 msgid "SET_DESCRIPTION"
-msgstr "Set Description"
+msgstr "Cambiar descripción"
 
 msgid "SET_DESCRIPTION_INSTRUCTIONS"
-msgstr "Enter the new description for your Flipnote below."
+msgstr "Escribe una nueva descripción para tu Flipnote en el cuadro."
 
 msgid "101_CHARACTER_LIMIT_DESC"
-msgstr "Your description is limited to 101 characters in length."
+msgstr "Tu descripción está limitada a 101 caracteres de longitud."
 
 msgid "LEAVE_BLANK_TO_RESET_DESC"
-msgstr "To remove the description, leave the form blank when submitting."
+msgstr "Para quitar la descripción, deja el cuadro en blanco antes de confirmar."
 
 msgid "ENTER_DESCRIPTION"
-msgstr "Enter description..."
+msgstr "Escribir descripción..."
 
 msgid "HEADER_FLIPNOTE_OPTIONS"
-msgstr "Options"
+msgstr "Opciones"
 

--- a/es_ES/LC_MESSAGES/emailVerificationReminder.po
+++ b/es_ES/LC_MESSAGES/emailVerificationReminder.po
@@ -1,19 +1,19 @@
 msgid "EMAIL_SUBJECT"
-msgstr "[Sudomemo] You need to verify your email address"
+msgstr "[Sudomemo] Verifica tu dirección de correo"
 
 msgid "VERIFICATION_HEADER"
-msgstr "Sudomemo - Verify Email"
+msgstr "Sudomemo - Verifica tu correo"
 
 msgid "TEXT_HELLO_FORMAT"
-msgstr "Hello, %s!"
+msgstr "¡Hola, %s!"
 
 msgid "TEXT_NEED_TO_VERIFY_EMAIL"
-msgstr "This is a reminder that you need to verify your email address on Sudomemo."
+msgstr "Este es un recordatorio para que verifiques tu dirección de correo electrónico."
 
 msgid "TEXT_LOGIN_WITH_DSI_TO_VERIFY"
-msgstr "You can have a new verification email sent to you by logging into Sudomemo with your Nintendo DSi System."
+msgstr "Puedes recibir un correo de verificación nuevo al ingresar a Sudomemo en tu Nintendo DSi."
 
 msgid "TEXT_NEED_HELP_CONNECTION_INFO_LINK_FORMAT"
-msgstr "Need help connecting to Sudomemo? The setup guide can be found here: %s"
+msgstr "¿Necesitas ayuda para conectarte a Sudomemo? La guía de conexión se puede encontrar aquí: %s"
 
 

--- a/es_ES/LC_MESSAGES/flipnoteComments.po
+++ b/es_ES/LC_MESSAGES/flipnoteComments.po
@@ -20,32 +20,32 @@ msgid "NO_COMMENTS_YET"
 msgstr "Esta Flipnote aún no tiene comentarios."
 
 msgid "LOGIN_REQUIRED_TO_POST_COMMENT"
-msgstr "Debes haber iniciado sesión para publicar un comentario."
+msgstr "Debes iniciar sesión para publicar un comentario."
 
 msgid "COMMENT_POST_FAILED"
-msgstr "Ha ocurrido un error al publicar el comentario. Intenta de nuevo en otro momento."
+msgstr "Ha ocurrido un error al publicar el comentario. Intenta de nuevo más tarde."
 
 msgid "NO_BLANK_COMMENTS_ALLOWED"
 msgstr "No puedes publicar un comentario vacío."
 
 msgid "FLIPNOTE_DATA_CORRUPTED"
-msgstr "Los datos de esta Flipnote estan corruptos. Intenta de nuevo en un momento."
+msgstr "Los datos de esta Flipnote estan corruptos. Intenta de nuevo más tarde."
 
 msgid "FLIPNOTE_COMMENTS_DISALLOWED"
 msgstr "No puedes comentar en esta Flipnote."
 
 msgid "NO_COMMENTS_WHILE_MUTED"
-msgstr "Has sido muteado. No puedes publicar un comentario si estas muteado."
+msgstr "Has sido silenciado. No puedes publicar comentarios."
 
 msgid "DUPLICATE_COMMENT_FAILED"
 msgstr "Este comentario ya ha sido publicado en Sudomemo."
 
 msgid "COMMENT_FAILED_USER_BANNED"
-msgstr "Tu interacción ha sido restringido de Sudomemo."
+msgstr "Tus interacciones en Sudomemo han sido restringidas."
 
 msgid "CONFIRM_EMAIL_BEFORE_POSTING"
 msgstr "Por favor, confirma tu correo antes de publicar."
 
 msgid "MODERATOR"
-msgstr "Moderator"
+msgstr "Moderador"
 

--- a/es_ES/LC_MESSAGES/flipnoteOptions.po
+++ b/es_ES/LC_MESSAGES/flipnoteOptions.po
@@ -1,39 +1,39 @@
 msgid "FLIPNOTE_OPTIONS"
-msgstr "Flipnote Options"
+msgstr "Opciones de Flipnote"
 
 msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
-msgstr "You must be logged in to view this page."
+msgstr "Debes iniciar sesión para ver esta página."
 
 msgid "HEADER_OPTION"
-msgstr "Option"
+msgstr "Opción"
 
 msgid "HEADER_STATUS"
-msgstr "Status"
+msgstr "Estado"
 
 msgid "OPTION_NAME_SMOOTH"
-msgstr "Smoothing"
+msgstr "Suavizado"
 
 msgid "OPTION_DESC_SMOOTH"
-msgstr "Lines, curves, and edges are smoothed for a more natural look on Sudomemo Theatre."
+msgstr "Las líneas, curvas y esquinas están suavizadas para un look más natural. Se aplica en Sudomemo Theatre."
 
 msgid "FLIPNOTE_URL_IS"
-msgstr "Flipnote URL:"
+msgstr "Enlace de Flipnote:"
 
 msgid "ENABLE_SMOOTHING"
-msgstr "Enable smoothing"
+msgstr "Activar suavizado"
 
 msgid "DISABLE_SMOOTHING"
-msgstr "Disable smoothing"
+msgstr "Apagar suavizado"
 
 msgid "ON"
-msgstr "On"
+msgstr "Sí"
 
 msgid "OFF"
-msgstr "Off"
+msgstr "No"
 
 msgid "CITIZENSHIP_REQUIRED"
-msgstr "You'll need Sudomemo Citizenship to use this feature."
+msgstr "Necesitas Ciudadanía de Sudomemo para usar esta función."
 
 msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
-msgstr "Tap on an option's status to view or change it."
+msgstr "Toca en los estados de las opciones para más detalles."
 

--- a/es_ES/LC_MESSAGES/followNotificationEmail.po
+++ b/es_ES/LC_MESSAGES/followNotificationEmail.po
@@ -1,24 +1,24 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] %s added you to their Favorites"
+msgstr "[Sudomemo] %s te ha añadido a sus favoritos"
 
 msgid "GREETING_FORMAT"
-msgstr "Hey %s!"
+msgstr "¡Hola, %s!"
 
 msgid "NEW_FOLLOWER_ADDED_YOU_FORMAT"
-msgstr "%s just added you to their Favorites."
+msgstr "%s te ha añadido a sus favoritos."
 
 msgid "STATS_FLIPNOTES_FORMAT"
 msgstr "%s Flipnotes"
 
 msgid "STATS_FOLLOWERS_FORMAT"
-msgstr "%s Followers"
+msgstr "%s Seguidores"
 
 msgid "STATS_FLIPNOTES_FORMAT_SINGULAR"
 msgstr "%s Flipnote"
 
 msgid "STATS_FOLLOWERS_FORMAT_SINGULAR"
-msgstr "%s Follower"
+msgstr "%s Seguidor"
 
 msgid "VIEW_PROFILE"
-msgstr "View Profile"
+msgstr "Ver perfil"
 

--- a/es_ES/LC_MESSAGES/inbox.po
+++ b/es_ES/LC_MESSAGES/inbox.po
@@ -1,12 +1,12 @@
 msgid "HEADER_INBOX"
-msgstr "Inbox"
+msgstr "Bandeja de entrada"
 
 # this must be a max of 6 characters
 msgid "UNAUTHED_READ"
-msgstr "Leer.."
+msgstr "Leer..."
 
 msgid "PREV"
-msgstr "Prev"
+msgstr "Ant."
 
 msgid "NEXT"
 msgstr "Sig."

--- a/es_ES/LC_MESSAGES/localeSelection.po
+++ b/es_ES/LC_MESSAGES/localeSelection.po
@@ -1,11 +1,11 @@
 msgid "CHANGE_LANGUAGE"
-msgstr "Cambiar Idioma"
+msgstr "Cambiar idioma"
 
 msgid "LANGUAGE_UPDATED_FORMAT"
 msgstr "Tu idioma ha sido cambiado a %s."
 
 msgid "POTENTIAL_CONTRIBUTOR_NOTE"
-msgstr "Sudomemo confía en su comunidad para ofrecer traducciones acertadas. Si tu ves algo que no se muestra correctamente, aún sigue en inglés, es un traducción de baja calidad, o si te gustaría agregar tu propio idioma, ¡te invitamos a contribuir! Nuevas traducciones completas y verificadas puden darte ciudadanía en Sudomemo. Puedes hacerlo aquí: https://github.com/Sudomemo/sudomemo-locales"
+msgstr "Sudomemo confía en su comunidad para ofrecer traducciones precisas. Si ves algo que no se muestra correctamente, aún sigue en inglés, es un traducción de baja calidad, o si te gustaría agregar tu propio idioma, ¡te invitamos a contribuir! Nuevas traducciones completas y verificadas puden darte ciudadanía en Sudomemo. Puedes hacerlo aquí: https://github.com/Sudomemo/sudomemo-locales"
 
 msgid "RETURN_TO_CREATORS_ROOM"
 msgstr "Regresar a la Sala del Creador"

--- a/es_ES/LC_MESSAGES/login.po
+++ b/es_ES/LC_MESSAGES/login.po
@@ -8,13 +8,13 @@ msgid "BAN_NOTICE_PLEASE_READ_BAN_LETTER"
 msgstr "Por favor lee la nota que te hemos enviado para más información..."
 
 msgid "BAN_VIEW_MAIL"
-msgstr "Vista del Correo de Sudomemo"
+msgstr "Ver el Correo de Sudomemo"
 
 msgid "LOGIN_SUCCESSFUL"
-msgstr "Ha iniciado sesión exitosamente"
+msgstr "¡Éxito!"
 
 msgid "THANKS_FOR_LOGIN_FORMAT"
-msgstr "Gracias por iniciar sesión, %s!"
+msgstr "¡Gracias por iniciar sesión, %s!"
 
 msgid "GOTO_CREATORS_ROOM"
 msgstr "Ir a la Sala del Creador"
@@ -29,16 +29,16 @@ msgid "LOGIN_SETUP"
 msgstr "Configuración de inicio de sesión"
 
 msgid "WELCOME_BACK_FORMAT"
-msgstr "Bienvenido de vuelta!, %s!"
+msgstr "¡Bienvenido de vuelta, %s!"
 
 msgid "RETURNING_USER_NEW_LOGIN_SYSTEM"
-msgstr "Desde la última vez que iniciaste sesión, hemos agregado un nuevo sistema de inicio de sesión -- Pero no te preocupes,¡ todo tu contenido sigue aqui!"
+msgstr "Desde la última vez que iniciaste sesión, hemos agregado un nuevo sistema de inicio de sesión -- Pero no te preocupes, ¡todo tu contenido sigue aqui!"
 
 msgid "RETURNING_USER_PLEASE_CREATE_PASSWORD"
 msgstr "Para comenzar, crea una nueva contraseña aquí abajo."
 
 msgid "NEW_USER_WELCOME_FORMAT"
-msgstr "Bienvenido a Sudomemo, %s!"
+msgstr "¡Bienvenido a Sudomemo, %s!"
 
 msgid "NEW_USER_PLEASE_CREATE_PASSWORD"
 msgstr "Por favor crea una nueva contraseña."
@@ -56,7 +56,7 @@ msgid "FORM_WARNING_PASSWORD_DISALLOWED_CHARS"
 msgstr "Tu contraseña no puede contener ninguno de estos caracteres:"
 
 msgid "FORM_LABEL_DONT_FORGET_PASSWORD"
-msgstr "¡Recuerda tener apuntada tu contraseña, y mantenerla segura!"
+msgstr "¡Recuerda tener apuntada tu contraseña, y mantenla segura!"
 
 msgid "FORM_HEADER_EMAIL"
 msgstr "Correo electrónico:"
@@ -68,7 +68,7 @@ msgid "FORM_WARNING_EMAIL_INVALID"
 msgstr "La dirección de Correo electrónico que has introducido no es válida."
 
 msgid "EMAIL_ADDITION_SUGGESTED"
-msgstr "El Correo electrónico es opcional, pero muy recomendado. Si llegas a olvidar tu contraseña, te enviaremos un Correo electrónico para que la recuperes."
+msgstr "El Correo electrónico es opcional, pero muy recomendado. Si llegas a olvidar tu contraseña, te enviaremos un correo electrónico para que la recuperes."
 
 msgid "EMAIL_ADDITION_DETAILS"
 msgstr "Si en algún momento pierdes tu contraseña, te enviaremos un enlace para reestablecerla a tu Correo electrónico."
@@ -86,10 +86,10 @@ msgid "FORM_HEADER_EMAIL_CONFIRM"
 msgstr "Correo electrónico:"
 
 msgid "BUTTON_CHANGE_EMAIL"
-msgstr "Cambiar dirección de Correo electrónico aquí"
+msgstr "Cambiar dirección de correo electrónico aquí"
 
 msgid "BUTTON_ADD_AN_EMAIL_ADDRESS"
-msgstr "Agregar dirección de Correo electrónico"
+msgstr "Agregar dirección de correo electrónico"
 
 msgid "BUTTON_SUBMIT"
 msgstr "Enviar"
@@ -134,10 +134,10 @@ msgid "LOGIN_FAILED_CORRUPTED_DATA_LINE1"
 msgstr "Los datos de esta Flipnote están corruptos."
 
 msgid "LOGIN_FAILED_CORRUPTED_DATA_LINE2"
-msgstr "Prueba mandarlo una vez más."
+msgstr "Prueba a enviarla una vez más."
 
 msgid "LOGIN_FAILED_BANNED_LINE1"
-msgstr "Tus interacciones han sido restringidas de Sudomemo."
+msgstr "Tus interacciones en Sudomemo han sido restringidas."
 
 msgid "CONTACT_SUPPORT_EMAIL_FORMAT"
 msgstr "Por favor contacta a %s."
@@ -152,7 +152,7 @@ msgid "GUIDE_MAIN_MENU_SHORTCUT"
 msgstr "Puedes regresar al menú principal presionando L (o R si eres zurdo) y el botón de 'Menú'."
 
 msgid "SORRY_NO_LOGIN"
-msgstr "Lo sentimos, ¡pero no pudimos iniciar tu sesión!"
+msgstr "Lo sentimos, pero no pudimos iniciar tu sesión."
 
 msgid "BASIC_AUTH_NOT_ENABLED"
 msgstr "No parece que tengas activado la Autenticación Básica en tus configuraciones de Proxy."
@@ -170,10 +170,10 @@ msgid "BASIC_AUTH_NONHEX_CHARACTERS"
 msgstr "El ID contiene otros caracteres que no son 0-9 y A-F (debería tener solo caracteres 0-9 y A-F)."
 
 msgid "SEEK_LOGIN_HELP_IN_DISCORD_FORMAT"
-msgstr "Si necesitas ayuda para conectarte, eres libre de preguntar en nuestro Discord! Puedes unirte desde %s."
+msgstr "Si necesitas ayuda para conectarte, ¡eres libre de preguntar en nuestro Discord! Puedes unirte desde %s."
 
 msgid "BAN_NOTICE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Por favor, contáctanos por Discord o vía Correo electrónico a %s."
+msgstr "Por favor, contáctanos por Discord o vía correo electrónico a %s."
 
 msgid "FORGOT_PASSWORD_LINK"
 msgstr "¿Olvidaste tu contraseña?"
@@ -182,40 +182,40 @@ msgid "EMAIL_IS_DUPLICATE"
 msgstr "El correo electrónico que ingresaste ya está en uso."
 
 msgid "EMAIL_CONFIRMATION_SENT_FORMAT"
-msgstr "Un Correo de confirmación ha sido enviado a %s. Por favor verifícalo en unos cuantos minutos."
+msgstr "Un correo de confirmación ha sido enviado a %s. Por favor verifícalo en unos cuantos minutos."
 
 msgid "BUTTON_CHECK_VERIFICATION"
 msgstr "Verificar el estado de confirmación"
 
 msgid "EMAIL_NOT_YET_VERIFIED"
-msgstr "Tu Correo electrónico aún no ha sido confirmado."
+msgstr "Tu correo electrónico aún no ha sido confirmado."
 
 msgid "EMAIL_VERIFIED"
-msgstr "¡Gracias por confirmar tu Correo!"
+msgstr "¡Gracias por confirmar tu correo!"
 
 msgid "EMAIL_REQUIRES_UPDATE"
-msgstr "Tu Correo electrónico necesita ser actualizado."
+msgstr "Tu correo electrónico necesita ser actualizado."
 
 msgid "VERIFICATION_NEEDED"
-msgstr "Necesitamos verificar tu Correo electrónico."
+msgstr "Necesitamos verificar tu correo electrónico."
 
 msgid "BUTTON_RESEND_VERIFICATION_EMAIL"
-msgstr "Re-enviar Correo de confirmación"
+msgstr "Reenviar correo de confirmación"
 
 msgid "NOT_RECEIVING_HELP_FORMAT"
-msgstr "¿Sigues sin recibir el Correo? Puedes hablar con nosotros en el Discord de Sudomemo o vía %s."
+msgstr "¿Sigues sin recibir el correo? Puedes hablar con nosotros en el Discord de Sudomemo o vía %s."
 
 msgid "HEADER_VERIFY_EMAIL"
-msgstr "Confirmar Correo"
+msgstr "Confirmar correo"
 
 msgid "VERIFICATION_LIMIT_EXCEEDED_FORMAT"
 msgstr "Has excedido el número máximo de correos de confirmación. Por favor, contáctanos por %s o vía Discord."
 
 msgid "WEB_HEADER_SUCCESS"
-msgstr "¡Exitoso!"
+msgstr "¡Éxito!"
 
 msgid "WEB_TAP_CHECK_VERIFICATION_STATUS"
-msgstr "Ve y presiona 'Verificar el estado de confirmación' en tu sistema Nintendo DSi."
+msgstr "Ve y toca 'Verificar el estado de confirmación' en tu sistema Nintendo DSi."
 
 msgid "HEADER_VERIFICATION_EXPIRED"
 msgstr "Confirmación expirada"
@@ -242,5 +242,5 @@ msgid "SEARCH_FOR_SENDER_EMAIL_FORMAT"
 msgstr "¿Aún no has recibido el correo? Échale un vistazo a tu correo basura (Spam), y busca por %s. Si lo encuentras y está marcado como Spam, por favor asegúrate de primero marcar No es Spam."
 
 msgid "NEW_USER_INTRO_POST_INTRO_CHANNEL"
-msgstr "When you're ready, go ahead and introduce yourself in our Introduction channel, under the Personal category."
+msgstr "Cuando estés preparado, introdúcete en el canal Introducciones, dentro de la sección Personal."
 

--- a/es_ES/LC_MESSAGES/mailSettings.po
+++ b/es_ES/LC_MESSAGES/mailSettings.po
@@ -2,7 +2,7 @@ msgid "HEADER_MAIL_SETTINGS"
 msgstr "Ajustes de Correo"
 
 msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
-msgstr "Debes haber iniciado sesión para editar tus Ajustes de Correo."
+msgstr "Debes iniciar sesión para editar tus Ajustes de Correo."
 
 msgid "MAIL_TYPE"
 msgstr "Tipo"
@@ -23,58 +23,58 @@ msgid "Disable"
 msgstr "Desabilitar"
 
 msgid "TAP_TO_ENABLE"
-msgstr "Presiona para habilitar"
+msgstr "Toca para habilitar"
 
 msgid "TAP_TO_DISABLE"
-msgstr "Presiona para desabilitar"
+msgstr "Toca para desabilitar"
 
 msgid "TYPE_NEWS_NAME"
 msgstr "Noticias de Sudomemo"
 
 msgid "TYPE_NEWS_DESC"
-msgstr "Recibe un Correo electrónico cuando algo nuevo sea publicado en las Noticas de Sudomemo"
+msgstr "Recibe un correo electrónico cuando algo nuevo sea publicado en las Noticas de Sudomemo."
 
 msgid "TYPE_PROMO_NAME"
 msgstr "Actualizaciones de servicio"
 
 msgid "TYPE_PROMO_DESC"
-msgstr "¡Reciba Correos electrónicos de nuevas funciones, consejos y eventos por venir!"
+msgstr "¡Recibe correos electrónicos de nuevas funciones, consejos y eventos por venir!"
 
 msgid "TYPE_FAVE_NOTIF_NAME"
 msgstr "Añadido como Favorito"
 
 msgid "TYPE_FAVE_NOTIF_DESC"
-msgstr "Reciba un Correo electrónico cuando alguien te añada a sus Favoritos"
+msgstr "Recibe un correo electrónico cuando alguien te añada a sus Favoritos."
 
 msgid "TYPE_COMMENT_NOTIF_NAME"
 msgstr "Comentario recibido"
 
 msgid "TYPE_COMMENT_NOTIF_DESC"
-msgstr "Reciba un Correo electrónico cuando alguien comente en una de tus Flipnotes"
+msgstr "Reciba un correo electrónico cuando alguien comente en una de tus Flipnotes."
 
 msgid "TYPE_STAR_REPORT_NAME"
 msgstr "Reporte Diario de Estrellas"
 
 msgid "TYPE_STAR_REPORT_DESC"
-msgstr "Recibe un Correo electrónico al final del día acerca de las estrellas recibidas"
+msgstr "Recibe un correo electrónico al final del día acerca de las estrellas recibidas."
 
 msgid "TYPE_SPINOFF_NOTIF_NAME"
 msgstr "Spin-off Recibida"
 
 msgid "TYPE_SPINOFF_NOTIF_DESC"
-msgstr "Recibe un Correo electrónico cuando alguien suba una spin-off de alguna de tus Flipnotes "
+msgstr "Recibe un correo electrónico cuando alguien suba una spin-off de alguna de tus Flipnotes."
 
 msgid "TYPE_SECURITY_NOTIF_NAME"
 msgstr "Seguridad de la cuenta"
 
 msgid "TYPE_SECURITY_NOTIF_DESC"
-msgstr "Recibe un Correo electrónico cuando tu dirección de Correo electrónico o contraseña sea actualizada"
+msgstr "Recibe un correo electrónico cuando tu dirección de correo electrónico o contraseña sea actualizada"
 
 msgid "TYPE_REPORT_UPDATE_NAME"
 msgstr "Actualización de contenido reportado"
 
 msgid "TYPE_REPORT_UPDATE_DESC"
-msgstr "Recibe un Correo electrónico cuando actualizemos el estado de contenido que hayas reportado"
+msgstr "Recibe un correo electrónico cuando actualizemos el estado de contenido que hayas reportado"
 
 msgid "TYPE_UNREAD_COMMENTS_NAME"
 msgstr "Unread Comments"
@@ -83,10 +83,10 @@ msgid "TYPE_UNREAD_COMMENTS_DESC"
 msgstr "Receive an email summary of any new comments you've received recently"
 
 msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
-msgstr "Presiona el estado de un tipo de Correo para verlo o actualizarlo"
+msgstr "Toca el estado de un tipo de correo para verlo o actualizarlo"
 
 msgid "HEADER_CHANGE_EMAIL_SETTINGS"
-msgstr "Cambiar los ajustes de Correo"
+msgstr "Cambiar los ajustes de correo"
 
 msgid "DISABLE_CONFIRMATION_FORMAT"
 msgstr "¿Estas seguro de que quieres desabilitar los Correos de '%s'?"

--- a/es_ES/LC_MESSAGES/menuHeaders.po
+++ b/es_ES/LC_MESSAGES/menuHeaders.po
@@ -1,5 +1,5 @@
 msgid "WATCH_FLIPNOTES"
-msgstr "@Todas las Flipnotes"
+msgstr "Todas las Flipnotes"
 
 msgid "CHANNELS"
 msgstr "Canales"
@@ -11,7 +11,7 @@ msgid "FEATURED"
 msgstr "Destacados"
 
 msgid "HOT_FLIPNOTES"
-msgstr "@Flipnotes recientes"
+msgstr "Flipnotes recientes"
 
 msgid "ABOUT_SUDOMEMO"
 msgstr "Acerca de Sudomemo"
@@ -20,7 +20,7 @@ msgid "CREATORS_ROOM"
 msgstr "Sala del Creador"
 
 msgid "NEWS"
-msgstr "@Noticias Sudomemo"
+msgstr "Noticias Sudomemo"
 
 msgid "CHATROOMS"
 msgstr "Salas de Chat"

--- a/es_ES/LC_MESSAGES/passwordResetEmail.po
+++ b/es_ES/LC_MESSAGES/passwordResetEmail.po
@@ -14,7 +14,7 @@ msgid "TEXT_RESET_LINK_FORMAT"
 msgstr "Presiona <a target=\"_blank\" href=\"%s\">aquí</a> para continuar."
 
 msgid "TEXT_URL_PLAIN_DISPLAY"
-msgstr "También puedes copiar y pegar esta URL en una nueva ventana:"
+msgstr "También puedes copiar y pegar este enlace en una nueva ventana:"
 
 msgid "PASSWORD_RESET_SENT_FORMAT"
 msgstr "Una solicitud de reestablecimiento de contraseña ha sido enviado al correo electrónico %s."
@@ -23,7 +23,7 @@ msgid "NO_EMAIL_CONTACT_SUPPORT"
 msgstr "No tienes un dirección de correo electrónico en nuestro archivo. Por favor, contácta al Soporte de Sudomemo en nuestro servidor de Discord."
 
 msgid "HEADER_FORGOT_PASSWORD"
-msgstr "Olvidáste tu Contraseña"
+msgstr "¿Olvidaste tu contraseña?"
 
 msgid "SESSION_EXPIRED"
 msgstr "Tu sesión ha expirado, intenta de nuevo."

--- a/es_ES/LC_MESSAGES/reportContent.po
+++ b/es_ES/LC_MESSAGES/reportContent.po
@@ -26,16 +26,16 @@ msgid "CREATOR_FORMAT"
 msgstr "Creador: %s"
 
 msgid "NOTICE_REPORT_OTHER_ISSUES"
-msgstr "Este formulario es para reportar contenido de usuarios exclusivamente. Para reportar el comportamiento de un Usuario, o por otros asuntos y peticiones, por favor manda un Correo electrónico a nuestro soporte técnico:"
+msgstr "Este formulario es para reportar contenido de usuarios exclusivamente. Para reportar el comportamiento de un usuario, o por otros asuntos y peticiones, por favor envia un correo electrónico a nuestro soporte técnico:"
 
 msgid "REPORT_INSTRUCTIONS"
-msgstr "Por favor escribe una corta descripción  de por qué crees que este contenido es una violación de los Términos de Uso de Sudomemo. Una vez envíes esto, presiona Atrás para regresar a la Flipnote"
+msgstr "Por favor escribe una corta descripción de por qué crees que este contenido es una violación de los Términos de Uso de Sudomemo. Una vez envíes esto, toca Atrás para regresar a la Flipnote"
 
 msgid "NO_BLANK_REPORTS"
 msgstr "No puedes enviar un reporte en blanco."
 
 msgid "LIMIT_ONE_REPORT"
-msgstr "Porfavor nota: Debes reportar este contenido solo una vez. Reportes adicionales no serán registrados, así que por favor coloca la información en un solo comentario."
+msgstr "Importante: Debes reportar este contenido solo una vez. Reportes adicionales no serán registrados, así que por favor coloca la información en un solo comentario."
 
 msgid "REPORT_EXPLANATION_FAILED"
 msgstr "Un error ocurrió mientras este reporte estaba siendo enviado."
@@ -44,19 +44,19 @@ msgid "RESTRICTED_CANCEL"
 msgstr "No debes reportar contenido si has sido restringido de interactuar con Sudomemo de cualquier manera."
 
 msgid "HEADER_REASON"
-msgstr "Razón:"
+msgstr "Motivo:"
 
 msgid "LOGIN_REQUIRED_TO_CONTINUE"
-msgstr "Debes haber iniciado sesión para continuar."
+msgstr "Inicia sesión para continuar."
 
 msgid "LOGIN_REQUIRED_TO_REPORT_CONTENT"
-msgstr "Debes haber iniciado sesión para enviar reportes de contenido."
+msgstr "Inicia sesión para enviar reportes de contenido."
 
 msgid "REPORT_FAILED_USER_BANNED"
-msgstr "Reporte fallido: Estas restringido de Sudomemo."
+msgstr "Reporte fallido: Estás restringido de Sudomemo."
 
 msgid "DUPLICATE_COMMENT_FAILED"
 msgstr "Este comentario ya ha sido publicado en Sudomemo."
 
 msgid "CONFIRM_EMAIL_BEFORE_REPORTING"
-msgstr "Por favor confirma tu Correo electrónico antes de reportar contenido."
+msgstr "Por favor confirma tu correo electrónico antes de reportar contenido."

--- a/es_ES/LC_MESSAGES/search.po
+++ b/es_ES/LC_MESSAGES/search.po
@@ -20,7 +20,7 @@ msgid "SEARCH_USERNAME"
 msgstr "Buscar nombre de usuario"
 
 msgid "PLEASE_ENTER_USERNAME"
-msgstr "Por favor introduzca un nombre de usuario..."
+msgstr "Por favor, introduce un nombre de usuario..."
 
 msgid "RESULTS_FOUND_FORMAT_SINGULAR"
 msgstr "%1$d Resultado encontrado para \"%2$s\""
@@ -32,14 +32,14 @@ msgid "NO_RESULTS_FOUND"
 msgstr "No se encontraron resultados"
 
 msgid "SEARCH_SHORT_KEY"
-msgstr "Flipnote ID"
+msgstr "ID de Flipnote"
 
 msgid "SHORT_KEY_NO_RESULTS"
 msgstr "Flipnote no encontrada"
 
 msgid "SHORT_KEY_FORMAT_GUIDE"
-msgstr "¿No encuentras lo que estás buscando? Debes haber ingresar la Flipnote ID incorrectamente. Las Flipnote ID son de seis dígitos y pueden ser encontradas en los sección de detalles de la Flipnote."
+msgstr "¿No encuentras lo que estás buscando? Debes haber ingresar la ID de Flipnote incorrectamente. Las ID de Flipnote son de seis dígitos y pueden ser encontradas en los sección de detalles de la Flipnote."
 
 msgid "SHORT_KEY_SIMILAR_FOUND_CASE_SENSITIVE"
-msgstr "No se han encontrado resultados, pero existe una ID similar. Por favor nota que las Flipnote ID distinguen letras mayúsculas y minúsculas, usualmente todas son mayúsculas y contienen números."
+msgstr "No se han encontrado resultados, pero existe una ID similar. Por favor nota que las ID de Flipnote distinguen letras mayúsculas y minúsculas. Por lo general, todas son mayúsculas y contienen números."
 

--- a/es_ES/LC_MESSAGES/themeShop.po
+++ b/es_ES/LC_MESSAGES/themeShop.po
@@ -1,20 +1,20 @@
 msgid "THEME_SHOP_LOGIN_REQUIRED"
-msgstr "Debes haber iniciado sesión para accesar a la Tienda de Temas"
+msgstr "Inicia sesión para acceder a la Tienda de Temas"
 
 msgid "THEME_SHOP_MAINPAGE_HEADER"
-msgstr "¡Aquí en la Tienda de Temas puedes comprar nuevos temas para tu Sala del Creador!"
+msgstr "¡En la Tienda de Temas, puedes comprar nuevos temas para tu Sala del Creador!"
 
 msgid "THEME_SHOP_LEARN_MORE_HEADER"
 msgstr "Aprende más acerca de la Tienda de Temas"
 
 msgid "THEME_SHOP_REPORT_ISSUES_HEADER"
-msgstr "Presiona este link para reportar un tema que no esté funcionando correctamente."
+msgstr "Toca este enlace para reportar un tema que no esté funcionando correctamente."
 
 msgid "THEME_SHOP_MAINPAGE_EXCHANGE_COST_FORMAT"
 msgstr "Intercambia por %d Estrellas Verdes"
 
 msgid "THEME_SHOP_MAINPAGE_FREE_STARTER_THEMES"
-msgstr "Temas de Inicio Gratis"
+msgstr "Temas de inicio gratuitos"
 
 msgid "CONGRATULATIONS"
 msgstr "¡Felicidades!"
@@ -44,7 +44,7 @@ msgid "YOU_HAVE"
 msgstr "Tus Estrellas de Colores:"
 
 msgid "USERNAME"
-msgstr "Nombre de usuario0"
+msgstr "Nombre de usuario:"
 
 msgid "CANCEL"
 msgstr "Cancelar"
@@ -71,7 +71,7 @@ msgid "THEME_SHOP_STAR_BALANCE_TOO_LOW"
 msgstr "Lo siento, no tienes suficientes Estrellas Verdes para comprar este tema."
 
 msgid "THEME_SHOP_CHOOSE_CAREFULLY_BEFORE_BUYING"
-msgstr "¡Todas las compras son permanentes, por favor elige con cuidado antes de comprar!"
+msgstr "Todas las compras son permanentes, así que elige con cuidado antes de comprar."
 
 msgid "THEME_SHOP_YOU_OWN_THIS_THEME"
 msgstr "Ya tienes este tema."

--- a/es_ES/LC_MESSAGES/unfulfilledSignupEmail.po
+++ b/es_ES/LC_MESSAGES/unfulfilledSignupEmail.po
@@ -1,18 +1,18 @@
 msgid "EMAIL_SUBJECT"
-msgstr "Confirmación de Registro de Sudomemo"
+msgstr "Confirmación de registro de Sudomemo"
 
 msgid "SIGNUP_HEADER"
-msgstr "Confirmación de Registro de Sudomemo"
+msgstr "Confirmación de registro de Sudomemo"
 
 msgid "TEXT_HELLO"
 msgstr "¡Hola!"
 
 msgid "TEXT_EMAIL_PURPOSE"
-msgstr "Este Correo electrónico es para confirmar tu Registro en Sudomemo."
+msgstr "Este correo electrónico es para confirmar tu registro en Sudomemo."
 
 msgid "TEXT_VERIFICATION_LINK_FORMAT"
 msgstr "¡Presione <a target=\"_blank\" href=\"%s\">Aquí</a> para continuar!"
 
 msgid "TEXT_URL_PLAIN_DISPLAY"
-msgstr "También puedes copiar y pegar esta URL en una nueva ventana:"
+msgstr "También puedes copiar y pegar este enlace en una nueva ventana:"
 

--- a/es_ES/LC_MESSAGES/unreadComments.po
+++ b/es_ES/LC_MESSAGES/unreadComments.po
@@ -1,5 +1,5 @@
 msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
-msgstr "Debes haber iniciado sesión para ver esta página."
+msgstr "Inicia sesión para ver esta página."
 
 msgid "HEADER_UNREAD_COMMENTS"
 msgstr "Comentarios no leídos"
@@ -8,10 +8,10 @@ msgid "NO_UNREAD_COMMENTS"
 msgstr "No tienes comentarios sin leer."
 
 msgid "TAP_ON_FLIPNOTE_ID_TO_VISIT_COMMENTS"
-msgstr "Presiona en una Flipnote ID para visitar la página de comentarios."
+msgstr "Toca en una ID de Flipnote para visitar la página de comentarios."
 
 msgid "FLIPNOTE_ID"
-msgstr "Flipnote ID"
+msgstr "ID de Flipnote"
 
 msgid "UNREAD"
 msgstr "No leído"

--- a/es_ES/LC_MESSAGES/unreadCommentsEmail.po
+++ b/es_ES/LC_MESSAGES/unreadCommentsEmail.po
@@ -1,20 +1,20 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] %s, you've got new comments on your Flipnotes!"
+msgstr "[Sudomemo] ¡%s, tienes nuevos comentarios en tu Flipnote!"
 
 msgid "TITLE_NEW_COMMENTS"
-msgstr "New Comments"
+msgstr "Nuevos comentarios"
 
 msgid "HELLO_FORMAT"
-msgstr "Hello, %s!"
+msgstr "¡Hola, %s!"
 
 msgid "TEXT_YOU_HAVE_X_COMMENTS_FROM_FORMAT"
-msgstr "You have %d new comment(s) on Sudomemo from %s"
+msgstr "Tienes %d nuevo(s) commentarios en Sudomemo de %s"
 
 msgid "AND"
-msgstr "and"
+msgstr "y"
 
 msgid "AND_X_OTHERS_FORMAT"
-msgstr "and %s others."
+msgstr "y %s más."
 
 msgid "TEXT_HOW_TO_VIEW_UNREAD_COMMENTS_TAP_ICON_FORMAT"
-msgstr "You can view your unread comments on Sudomemo by tapping %s on your notification bar."
+msgstr "Puedes ver tus comentarios sin leer tocando %s en tu barra de notificaciones."


### PR DESCRIPTION
This is my first time using GitHub, so I can't say I'm very familiar with working with it.

Here's what I did:
-Fixed some typos and some punctuation issues.
-Rewrote certain parts of the translation, like awkwardly written phrases and excessively long text, to the point where it doesn't even fit on the screen. (Example: Navegar entre las Flipnotes = Ver Flipnotes, or Vista = Ver.)
-Translated several unstranslated strings (like the biography stuff or some email strings).
-The chatroom strings were referring to comments, for some reason. That has been fixed.

Some of the changes I made might seem like nitpicks, but I tried my best to make it look more or less professional.