### PR TITLE
Updated Sudomemo to Dutch again.

### DIFF
--- a/nl_NL/LC_MESSAGES/channelCategories.po
+++ b/nl_NL/LC_MESSAGES/channelCategories.po
@@ -23,4 +23,4 @@ msgid "PERSONAL"
 msgstr "Persoonlijk"
 
 msgid "WEEKLY_TOPICS"
-msgstr "Wekelijkse onderwerpen"
+msgstr "Wekelijkse Onderwerpen"

--- a/nl_NL/LC_MESSAGES/channelDetails.po
+++ b/nl_NL/LC_MESSAGES/channelDetails.po
@@ -35,4 +35,4 @@ msgid "CONFIRM_EMAIL_BEFORE_POSTING"
 msgstr "Bevestig alsjeblieft je e-mailadres voor je iets plaatst."
 
 msgid "NO_POSTS_WHILE_MUTED"
-msgstr "You may not post while you are muted."
+msgstr "Je mag niet plaatsen terwijl je op stil gezet bent."

--- a/nl_NL/LC_MESSAGES/creatorsRoom.po
+++ b/nl_NL/LC_MESSAGES/creatorsRoom.po
@@ -80,10 +80,10 @@ msgid "BLOCK_COMMENTS_LINK"
 msgstr "Blokkeer"
 
 msgid "USABILITY_USABLE"
-msgstr "Gebruikbaar"
+msgstr "Bruikbaar"
 
 msgid "USABILITY_NOT_USABLE"
-msgstr "Ongebruikbaar"
+msgstr "Onbruikbaar"
 
 msgid "HEADER_FOLLOWERS"
 msgstr "Volgers"
@@ -125,10 +125,10 @@ msgid "THEMETEST_NOTICE_2"
 msgstr "Notitie #2"
 
 msgid "THEMETEST_ACTIVE_TAB"
-msgstr "Actieve tabblad"
+msgstr "Actief tabblad"
 
 msgid "THEMETEST_INACTIVE_TAB"
-msgstr "Inactieve tabblad"
+msgstr "Inactief tabblad"
 
 msgid "PREVIEW"
 msgstr "Voorbeeld"
@@ -158,44 +158,44 @@ msgid "HEADER_MAIL_SETTINGS"
 msgstr "E-mail Instellingen"
 
 msgid "HEADER_EDIT_BIOGRAPHY"
-msgstr "Edit Biography"
+msgstr "Verander Biografie"
 
 msgid "SET_BIO_INSTRUCTIONS"
-msgstr "Enter your profile biography below. This will be displayed on Sudomemo and Sudomemo Theatre."
+msgstr "Vul je profiel biografie hieronder in. Dit zal weergeven worden op Sudomemo en Sudomemo Theater."
 
 msgid "ENTER_BIO"
-msgstr "Enter Bio..."
+msgstr "Vul Bio in..."
 
 msgid "101_CHARACTER_LIMIT_BIO"
-msgstr "Your biography is limited to 101 characters."
+msgstr "Je biografie is gelimiteerd tot 101 tekens."
 
 msgid "LEAVE_BLANK_TO_RESET_BIO"
-msgstr "To clear your biography, leave the form blank when submitting."
+msgstr "Om je biografie te verwijderen, laat het formulier leeg bij het insturen."
 
 msgid "CURRENT_BIO"
-msgstr "Current Bio:"
- 
-msgid "FOLLOW_LIMIT_EXCEEDED_FORMAT"
-msgstr "You can't follow more than %d users."
+msgstr "Huidige Bio:"
 
+msgid "FOLLOW_LIMIT_EXCEEDED_FORMAT"
+msgstr "Je kan niet meer dan %d gebruikers volgen."
+
+# The Dutch word for this depends on the context. I'll have a look what it's used for and change it if needed.
 msgid "RANKING"
-msgstr "Ranking"
+msgstr "Rang"
 
 msgid "TICKET_SECTION"
-msgstr "Tickets"
+msgstr "Prijskaarten"
 
 msgid "DRAW_REGULAR_TICKET"
-msgstr "Draw Ticket"
+msgstr "Trek Prijskaart"
 
 msgid "CAN_DRAW_TICKET_SUBTEXT"
-msgstr "You can draw a regular ticket! You might win a prize."
+msgstr "Je kan een reguliere ticket trekken! Misschien win je een prijs."
 
 msgid "INVENTORY"
-msgstr "Inventory"
+msgstr "Inventaris"
 
 msgid "TICKET_COOLDOWN_MESSAGE_FORMAT"
-msgstr "You can draw another ticket in: %s hour(s) %s minute(s)."
+msgstr "Je kan nog een prijskaart trekken in: %s uur %s minuut/minuten."
 
 msgid "REDEEM"
-msgstr "Redeem"
-
+msgstr "Wissel in"

--- a/nl_NL/LC_MESSAGES/creatorsRoom.po
+++ b/nl_NL/LC_MESSAGES/creatorsRoom.po
@@ -161,7 +161,7 @@ msgid "HEADER_EDIT_BIOGRAPHY"
 msgstr "Verander Biografie"
 
 msgid "SET_BIO_INSTRUCTIONS"
-msgstr "Vul je profiel biografie hieronder in. Dit zal weergeven worden op Sudomemo en Sudomemo Theater."
+msgstr "Vul je profiel biografie hieronder in. Dit zal weergeven worden op Sudomemo en Sudomemo Theatre."
 
 msgid "ENTER_BIO"
 msgstr "Vul Bio in..."

--- a/nl_NL/LC_MESSAGES/detailsPage.po
+++ b/nl_NL/LC_MESSAGES/detailsPage.po
@@ -17,7 +17,7 @@ msgid "HEADER_ORIGINAL_FLIPNOTE"
 msgstr "Bekijk de originele Flipnote hier"
 
 msgid "HEADER_NO_STARBEGGING_STAR_LIMIT"
-msgstr "Om vragen voor sterren te voorkomen, zijn gele sterren gelimiteerd tot tien per Flipnote."
+msgstr "Om vragen voor sterren ("Starbegging") te voorkomen, zijn gele sterren gelimiteerd tot tien per Flipnote."
 
 msgid "HEADER_CREATOR"
 msgstr "Maker"

--- a/nl_NL/LC_MESSAGES/flipnoteOptions.po
+++ b/nl_NL/LC_MESSAGES/flipnoteOptions.po
@@ -14,7 +14,7 @@ msgid "OPTION_NAME_SMOOTH"
 msgstr "Verzachting"
 
 msgid "OPTION_DESC_SMOOTH"
-msgstr "Lijnen, rondingen, en randen worden verzacht voor een meer natuurlijke uitstraling op Sudomemo Theater."
+msgstr "Lijnen, rondingen, en randen worden verzacht voor een meer natuurlijke uitstraling op Sudomemo Theatre."
 
 msgid "FLIPNOTE_URL_IS"
 msgstr "Flipnote URL:"

--- a/nl_NL/LC_MESSAGES/flipnoteOptions.po
+++ b/nl_NL/LC_MESSAGES/flipnoteOptions.po
@@ -1,39 +1,38 @@
 msgid "FLIPNOTE_OPTIONS"
-msgstr "Flipnote Options"
+msgstr "Flipnote Opties"
 
 msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
-msgstr "You must be logged in to view this page."
+msgstr "Je moet ingelogd zijn om deze pagina te weergeven."
 
 msgid "HEADER_OPTION"
-msgstr "Option"
+msgstr "Optie"
 
 msgid "HEADER_STATUS"
 msgstr "Status"
 
 msgid "OPTION_NAME_SMOOTH"
-msgstr "Smoothing"
+msgstr "Verzachting"
 
 msgid "OPTION_DESC_SMOOTH"
-msgstr "Lines, curves, and edges are smoothed for a more natural look on Sudomemo Theatre."
+msgstr "Lijnen, rondingen, en randen worden verzacht voor een meer natuurlijke uitstraling op Sudomemo Theater."
 
 msgid "FLIPNOTE_URL_IS"
 msgstr "Flipnote URL:"
 
 msgid "ENABLE_SMOOTHING"
-msgstr "Enable smoothing"
+msgstr "Verzachting inschakelen"
 
 msgid "DISABLE_SMOOTHING"
-msgstr "Disable smoothing"
+msgstr "Verzachting uitschakelen"
 
 msgid "ON"
-msgstr "On"
+msgstr "Aan"
 
 msgid "OFF"
-msgstr "Off"
+msgstr "Uit"
 
 msgid "CITIZENSHIP_REQUIRED"
-msgstr "You'll need Sudomemo Citizenship to use this feature."
+msgstr "Je hebt Sudomemo Citizenship nodig om deze functie te gebruiken."
 
 msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
-msgstr "Tap on an option's status to view or change it."
-
+msgstr "Tik op de status van een optie om deze te weergeven of te veranderen."

--- a/nl_NL/LC_MESSAGES/followNotificationEmail.po
+++ b/nl_NL/LC_MESSAGES/followNotificationEmail.po
@@ -1,24 +1,23 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] %s added you to their Favorites"
+msgstr "[Sudomemo] %s heeft je toegevoegd aan hun Favorieten"
 
 msgid "GREETING_FORMAT"
-msgstr "Hey %s!"
+msgstr "Hé %s!"
 
 msgid "NEW_FOLLOWER_ADDED_YOU_FORMAT"
-msgstr "%s just added you to their Favorites."
+msgstr "%s heeft je zojuist toegevoegd aan hun Favorieten."
 
 msgid "STATS_FLIPNOTES_FORMAT"
 msgstr "%s Flipnotes"
 
 msgid "STATS_FOLLOWERS_FORMAT"
-msgstr "%s Followers"
+msgstr "%s Volgers"
 
 msgid "STATS_FLIPNOTES_FORMAT_SINGULAR"
 msgstr "%s Flipnote"
 
 msgid "STATS_FOLLOWERS_FORMAT_SINGULAR"
-msgstr "%s Follower"
+msgstr "%s Volger"
 
 msgid "VIEW_PROFILE"
-msgstr "View Profile"
-
+msgstr "Profiel Weergeven"

--- a/nl_NL/LC_MESSAGES/happyBirthdayEmail.po
+++ b/nl_NL/LC_MESSAGES/happyBirthdayEmail.po
@@ -1,14 +1,14 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] Happy Birthday, %s!"
+msgstr "[Sudomemo] Gefeliciteerd, %s!"
 
 msgid "GREETING_FORMAT"
-msgstr "Hey %s!"
+msgstr "Hé %s!"
 
 msgid "HAPPY_BIRTHDAY"
-msgstr "Happy birthday!"
+msgstr "Van Harte Gefeliciteerd!"
 
 msgid "SPECIAL_SURPRISE_WAITING"
-msgstr "There's a special birthday surprise waiting for you on Sudomemo."
+msgstr "Er wacht een speciaal verjaardags verrassing voor je op Sudomemo."
 
 msgid "LOGON_ON_DS_TO_VIEW"
-msgstr "Log on to Sudomemo with your Nintendo DSi or 3DS to receive your birthday gift!"
+msgstr "Log in op Sudomemo met je Nintendo DSi of 3DS om je verjaardags cadeau te ontvangen!"

--- a/nl_NL/LC_MESSAGES/login.po
+++ b/nl_NL/LC_MESSAGES/login.po
@@ -53,7 +53,7 @@ msgid "FORM_WARNING_PASSWORD_TOO_SHORT"
 msgstr "Vul alsjeblieft een wachtwoord in dat langer is dan 8 lettertekens."
 
 msgid "FORM_WARNING_PASSWORD_DISALLOWED_CHARS"
-msgstr "Je wachtwoord mag niet een van de volgende tekens bevatten:"
+msgstr "Je wachtwoord mag geen van de volgende tekens bevatten:"
 
 msgid "FORM_LABEL_DONT_FORGET_PASSWORD"
 msgstr "Vergeet je wachtwoord niet, en houdt hem veilig!"
@@ -179,7 +179,7 @@ msgid "FORGOT_PASSWORD_LINK"
 msgstr "Wachtwoord vergeten?"
 
 msgid "EMAIL_IS_DUPLICATE"
-msgstr "Deze e-mailadres is al in gebruik."
+msgstr "Dit e-mailadres is al in gebruik."
 
 msgid "EMAIL_CONFIRMATION_SENT_FORMAT"
 msgstr "Een verificatie e-mail is verstuurd naar %s. Controleer je inbox alsjeblieft na een paar minuten."
@@ -233,14 +233,13 @@ msgid "THANK_YOU_FOR_UPDATING_EMAIL"
 msgstr "Bedankt voor het updaten van jouw e-mailadres!"
 
 msgid "BUTTON_CONTINUE"
-msgstr "Ga door"
+msgstr "Ga verder"
 
 msgid "BUTTON_EDIT_EMAIL_ADDRESS"
 msgstr "Verander E-mailadres"
 
 msgid "SEARCH_FOR_SENDER_EMAIL_FORMAT"
-msgstr "Geen e-mail ontvangen? Check je Spam box, en zoek voor %s. Als het blijkt dat het gemarkeert is als span, zorg er voor dat je het markeert als Geen Spam."
+msgstr "Geen e-mail ontvangen? Check je Spam box, en zoek voor %s. Als het blijkt dat het gemarkeerd is als spam, zorg er voor dat je het markeert als Geen Spam."
 
 msgid "NEW_USER_INTRO_POST_INTRO_CHANNEL"
-msgstr "When you're ready, go ahead and introduce yourself in our Introduction channel, under the Personal category."
-
+msgstr "Wanneer je er klaar voor bent, stel jezelf voor in onze Introduction kanaal, onder de Persoonlijk categorie."

--- a/nl_NL/LC_MESSAGES/mailSettings.po
+++ b/nl_NL/LC_MESSAGES/mailSettings.po
@@ -19,7 +19,7 @@ msgstr "Uitgeschakeld"
 msgid "ENABLE"
 msgstr "Inschakelen"
 
-msgid "Disable"
+msgid "DISABLE"
 msgstr "Uitschakelen"
 
 msgid "TAP_TO_ENABLE"

--- a/nl_NL/LC_MESSAGES/profilePicture.po
+++ b/nl_NL/LC_MESSAGES/profilePicture.po
@@ -8,7 +8,7 @@ msgid "CONTINUE_SET_AS_PROFILE_PICTURE"
 msgstr "Bevestig"
 
 msgid "CURRENT"
-msgstr "@Momenteel"
+msgstr "Momenteel"
 
 msgid "NEW"
 msgstr "Nieuw"

--- a/nl_NL/LC_MESSAGES/tickets.po
+++ b/nl_NL/LC_MESSAGES/tickets.po
@@ -1,99 +1,99 @@
 # Code Redemption
 
 msgid "REDEEM_CODE"
-msgstr "Redeem Code"
+msgstr "Verzilver Code"
 
 msgid "ENTER_CODE_TO_REDEEM"
-msgstr "Enter the code you'd like to redeem below."
+msgstr "Vul de code die je wilt verzilveren hieronder in."
 
 msgid "CODE_ALREADY_USED"
-msgstr "The code you entered has already been used."
+msgstr "De code die je hebt ingevuld is al eens gebruikt."
 
 msgid "CODE_INVALID"
-msgstr "The code you entered is invalid."
+msgstr "De code die je hebt ingevuld is ongeldig."
 
 msgid "CODE_NONEXISTING_OR_EXPIRED"
-msgstr "The code you entered doesn't exist or has expired."
+msgstr "De code die je hebt ingevuld bestaat niet of is verlopen."
 
 msgid "LOGIN_REQUIRED_REDEEM_CODE"
-msgstr "You must be logged in to redeem a code."
+msgstr "Je moet ingelogd zijn om een code te verzilveren."
 
 # Ticket delivery
 
 msgid "YOU_GOT_A_TICKET"
-msgstr "You got a ticket!"
+msgstr "Je hebt een prijskaart!"
 
 msgid "CONTINUE"
-msgstr "Continue"
+msgstr "Ga verder"
 
 # Inventory
 
 msgid "INVENTORY"
-msgstr "Inventory"
+msgstr "Inventaris"
 
 msgid "USE_ITEM"
-msgstr "Use"
+msgstr "Gebruik"
 
 msgid "INVENTORY_IS_EMPTY"
-msgstr "Your inventory is empty."
+msgstr "Je inventaris is leeg."
 
 # Ticket redemption
 
 msgid "TICKET_REDEEM_WIN_FORMAT"
-msgstr "You redeemed the %s!"
+msgstr "Je verzilvert het %s"
 
 msgid "TICKET_REDEEM_LOSE_FORMAT"
-msgstr "You redeemed the %s, but..."
+msgstr "Je verzilvert het %s, maar..."
 
 msgid "TICKET_REDEEM_NO_PRIZES"
-msgstr "You didn't win anything. Sorry!"
+msgstr "Je hebt niks gewonnen. Sorry!"
 
 msgid "COLOR_STARS"
-msgstr "Color Stars"
+msgstr "Kleur Sterren"
 
 msgid "CREATORS_ROOM_THEME"
-msgstr "Creator's Room Theme"
+msgstr "Maker's Ruimte Thema"
 
 msgid "SUDOMEMO_CITIZENSHIP"
 msgstr "Sudomemo Citizenship"
 
 msgid "THEME_AVAILABLE_FOR_USE"
-msgstr "You can now use this theme in your Creator's Room!"
+msgstr "Je kan nu deze thema gebruiken in je Maker's Ruimte!"
 
-# Each ticket type will have a name and a description 
+# Each ticket type will have a name and a description
 
 msgid "TICKET_NAME_demo_ticket"
-msgstr "Demo Ticket"
+msgstr "Demo Prijskaartje"
 
 msgid "TICKET_DESC_demo_ticket"
-msgstr "Obviously, this is the description for the demo ticket."
+msgstr "Vanzelfsprekend, dit is de beschrijving voor het demo prijskaartje."
 
 msgid "TICKET_NAME_regular_ticket"
-msgstr "Regular Ticket"
+msgstr "Regulier Prijskaartje"
 
 msgid "TICKET_DESC_regular_ticket"
-msgstr "Thank you for using Sudomemo!"
+msgstr "Bedankt voor het gebruiken van Sudomemo!"
 
 msgid "TICKET_NAME_twitter_promo_ticket"
-msgstr "Twitter Promo Ticket"
+msgstr "Twitter Promotie Prijskaartje"
 
 msgid "TICKET_DESC_twitter_promo_ticket"
-msgstr "Thanks for following the Sudomemo Twitter!"
+msgstr "Bedankt voor het volgen van de Sudomemo Twitter!"
 
 msgid "TICKET_NAME_instagram_promo_ticket"
-msgstr "Instagram Promo Ticket"
+msgstr "Instagram Promotie Prijskaartje"
 
 msgid "TICKET_DESC_instagram_promo_ticket"
-msgstr "Thanks for following the Sudomemo Instagram!"
+msgstr "Bedankt voor het volgen van de Sudomemo Instagram!"
 
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
-msgstr "Weekly Topic Winner Ticket"
+msgstr "Wekelijkse Onderwerp Winner Prijskaartje"
 
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
-msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
+msgstr "Gefeliciteerd met het winnen van de Sudomemo Wekelijkse Onderwerp!"
 
 msgid "TICKET_NAME_birthday_ticket"
-msgstr "Birthday Ticket"
+msgstr "Verjaardags Prijskaartje"
 
 msgid "TICKET_DESC_birthday_ticket"
-msgstr "Happy Birthday!"
+msgstr "Van Harte Gefeliciteerd!"


### PR DESCRIPTION
Overall stuff:

  * I translated the thousands and thousands of strings that haven't been
  translated when they should've. Oops lol
  * I also fixed some typo's and grammatical mistakes here and there. But, there are some special cases so I've added some comments below.

Comments:

  * RANKING in creatorsRoom.po:

    * The Dutch word for ranking depends on the context. I'll have a look on Sudomemo how it's used and change it if needed.

  * TICKET_COOLDOWN_MESSAGE_FORMAT in creatorsRoom.po:

    * "uur" is in Dutch both Singular and Plural, so it is grammatically correct. If you wondered.

  * CURRENT in profilePicture.po:

    * I removed the @ that was supposed to shorten it, because it just showed the @ on Sudomemo itself. I will try to find a shorter word in the future.

  * OPTION_NAME_SMOOTH & OPTION_DESC_SMOOTH in flipnoteOptions.po:

    * While "afronding" is the right word for "smoothing" in Dutch in this context, I have chosen for "verzachting" instead, which is "softening" in English. I have done this because "verzachting" gives less the feeling of that your Flipnote is changed than "afronding" does. "afronding" is the literal rounding of corners. I guess this is just a funk Dutch has.

  * DISABLE in mailSettings.po:

    * This was "Disable" at first, so I assumed it has to be "DISABLE" after looking at the en_US version