### PR TITLE
Update French translation

### DIFF
--- a/fr_FR/LC_MESSAGES/flipnoteOptions.po
+++ b/fr_FR/LC_MESSAGES/flipnoteOptions.po
@@ -35,7 +35,7 @@ msgid "CITIZENSHIP_REQUIRED"
 msgstr "Vous devez être un citoyen Sudomemo pour utiliser cette fonctionnalité."
 
 msgid "PLUS_REQUIRED"
-msgstr "You'll need Sudomemo Plus to use this feature."
+msgstr "Vous devez avoir Sudomemo Plus pour utiliser cette fonctionnalité."
 
 msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
 msgstr "Appuyez sur le statut d'une option pour l'afficher ou le modifier."

--- a/fr_FR/LC_MESSAGES/localeSelection.po
+++ b/fr_FR/LC_MESSAGES/localeSelection.po
@@ -5,7 +5,7 @@ msgid "LANGUAGE_UPDATED_FORMAT"
 msgstr "Votre langue a été réglée sur %s."
 
 msgid "POTENTIAL_CONTRIBUTOR_NOTE"
-msgstr "Sudomemo relies on its community to provide accurate translations. If you see something that does not display correctly, is still in English, is a low-quality translation, or if you would like to add your own language, we invite you to contribute! Full and verified new translations can earn you extra days of Sudomemo Plus. You can do so here: https://github.com/Sudomemo/sudomemo-locales"
+msgstr "Sudomemo compte sur sa communauté pour fournir des traductions exactes. Si vous voyez quelque chose qui ne s'affiche pas correctement, qui est toujours en anglais, qui est une traduction de mauvaise qualité, ou si vous voudriez ajouter votre propre langue, nous vous invitons à contribuer ! Les nouvelles traductions complètes et vérifiées peuvent vous rapporter des jours supplémentaires de Sudomemo Plus. Vous pouvez le faire ici : https://github.com/Sudomemo/sudomemo-locales"
 
 msgid "RETURN_TO_CREATORS_ROOM"
 msgstr "Retour à la salle de créateur"

--- a/fr_FR/LC_MESSAGES/sudomemoPlus.po
+++ b/fr_FR/LC_MESSAGES/sudomemoPlus.po
@@ -61,17 +61,17 @@ msgstr "Jouer à des jeux spéciaux directement sur Sudomemo !"
 # Sudomemo Plus Running Low Message
 
 msgid "PLUS_RUNNING_OUT_MSG_TITLE"
-msgstr "My Sudomemo Plus"
+msgstr "Mon Sudomemo Plus"
 
 msgid "PLUS_RUNNING_OUT_MSG_INTRO"
-msgstr "Hello, %s!"
+msgstr "Bonjour, %s !"
 
 msgid "PLUS_RUNNING_OUT_MSG_DAYS_REMAINING_FORMAT"
-msgstr "This message is to let you know that you have %s days of Sudomemo Plus remaining."
+msgstr "Ce message est là pour vous informer qu'il vous reste %s jours de Sudomemo Plus."
 
 msgid "PLUS_RUNNING_OUT_MSG_HOW_TO_EARN_PLUS"
-msgstr "Don't forget that you can earn Sudomemo Plus by entering winning entries to the Weekly Topic, or by redeeming tickets purchased from our Shop."
+msgstr "N'oubliez pas que vous pouvez obtenir Sudomemo Plus en gagnant au Weekly Topic, ou en utilisant des tickets achetés depuis notre boutique."
 
 msgid "PLUS_RUNNING_OUT_MSG_HAPPY_FLIPNOTING"
-msgstr "Happy Flipnoting!"
+msgstr "Bon flipnotage !"
 

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -108,8 +108,8 @@ msgid "TICKET_DESC_birthday_ticket"
 msgstr "Joyeux anniversaire !"
 
 msgid "TICKET_NAME_love_anniversary_ticket"
-msgstr "Ticket d'anniversaire"
+msgstr "Ticket annuel d'inscription"
 
 # The last character of this message is the DSi symbol for a heart. Don't remove it.
 msgid "TICKET_DESC_love_anniversary_ticket" 
-msgstr "Joyeux anniversaire "
+msgstr "Joyeux anniversaire sur Sudomemo "

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -112,4 +112,4 @@ msgstr "Ticket de célébration"
 
 # The last character of this message is the DSi symbol for a heart. Don't remove it.
 msgid "TICKET_DESC_love_anniversary_ticket" 
-msgstr "Joyeuse fête "
+msgstr "Joyeux anniversaire mon "

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -113,3 +113,16 @@ msgstr "Ticket de célébration"
 # The last character of this message is the DSi symbol for a heart. Don't remove it.
 msgid "TICKET_DESC_love_anniversary_ticket" 
 msgstr "Joyeux anniversaire mon "
+
+# Sudomemo Plus
+msgid "TICKET_NAME_one_month_plus_ticket"
+msgstr "Ticket Plus (Un mois)"
+
+msgid "TICKET_DESC_one_month_plus_ticket"
+msgstr "Ce ticket vous donnera un mois de Sudomemo Plus !"
+
+msgid "TICKET_NAME_one_year_plus_ticket"
+msgstr "Ticket Plus (Un an)"
+
+msgid "TICKET_DESC_one_year_plus_ticket"
+msgstr "Ce ticket vous donnera un an de Sudomemo Plus !"

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -108,8 +108,8 @@ msgid "TICKET_DESC_birthday_ticket"
 msgstr "Joyeux anniversaire !"
 
 msgid "TICKET_NAME_love_anniversary_ticket"
-msgstr "Anniversary Ticket"
+msgstr "Ticket d'anniversaire"
 
 # The last character of this message is the DSi symbol for a heart. Don't remove it.
 msgid "TICKET_DESC_love_anniversary_ticket" 
-msgstr "Happy Anniversary "
+msgstr "Joyeux anniversaire "

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -108,8 +108,8 @@ msgid "TICKET_DESC_birthday_ticket"
 msgstr "Joyeux anniversaire !"
 
 msgid "TICKET_NAME_love_anniversary_ticket"
-msgstr "Ticket annuel d'inscription"
+msgstr "Ticket de célébration"
 
 # The last character of this message is the DSi symbol for a heart. Don't remove it.
 msgid "TICKET_DESC_love_anniversary_ticket" 
-msgstr "Joyeux anniversaire sur Sudomemo "
+msgstr "Joyeuse fête "


### PR DESCRIPTION
What is the love_anniversary_ticket used for? Is it to celebrate a year since registration?

"Anniversaire" is the french for "Birthday" and for "Anniversary", the only thing that differentiates them is the context, so if I only write `Joyeux anniversaire` they will understand `Happy Birthday` instead of `Happy Anniversary`