### PR TITLE
Add Polish translation

### DIFF
--- a/pl_PL/LC_MESSAGES/blockSettings.po
+++ b/pl_PL/LC_MESSAGES/blockSettings.po
@@ -1,0 +1,59 @@
+msgid "LOGIN_REQUIRED_TO_MANAGE_BLOCKS"
+msgstr "Musisz się zalogować by zarządzać blokadami."
+
+msgid "NO_USERS_BLOCKED"
+msgstr "Nie masz zablokowanych użytkowników."
+
+msgid "BLOCKED_USERS"
+msgstr "Zablokowani użytkownicy"
+
+msgid "BLOCK_USER"
+msgstr "Blokuj użytkownika"
+
+msgid "COMMENT_BLOCK_IS_MUTUAL"
+msgstr "Po zablokowaniu tego użytkownika, nie będziecie mogli komentować na wzajemnych Flipnotes."
+
+msgid "USER_HAS_BEEN_BLOCKED"
+msgstr "Ten użytkownik został zablokowany."
+
+msgid "IF_YOU_WISH_TO_UNBLOCK"
+msgstr "Jeżeli chcesz go odblokować, możesz to zrobić wchodząc do twojego Pokoju Twórcy i otwierając menu Zablokowani użytkownicy."
+
+msgid "CONFIRM_BLOCK"
+msgstr "Potwierdź blokadę"
+
+msgid "USER_ALREADY_BLOCKED"
+msgstr "Zablokowałeś już tego użytkownika. Możesz go odblokować przez menu ustawień w twoim Pokoju Twórcy, ale wtedy będziesz musiał czekać 24 godziny zanim będziesz mógł zablokować go ponownie."
+
+msgid "ONE_DAY_WAIT_BEFORE_REBLOCK_FORMAT"
+msgstr "Niedawno odblokowałeś tego użytkownika. Możesz go odblokować za %s"
+
+msgid "UNBLOCK"
+msgstr "Odblokuj"
+
+msgid "LOGIN_REQUIRED"
+msgstr "Musisz się zalogować by wykonać tę operację."
+
+msgid "TAP_BACK_TO_RETURN"
+msgstr "Wciśnij Wróć by powrócić do twojego Pokoju Twórcy."
+
+msgid "UNBLOCK_USER"
+msgstr "Odblokuj użytkownika"
+
+msgid "CANNOT_UNBLOCK_NONBLOCKED_USER"
+msgstr "Nie możesz odblokować tego użytkownika, ponieważ jeszcze go nie zablokowałeś."
+
+msgid "USER_HAS_BEEN_UNBLOCKED"
+msgstr "Odblokowałeś tego użytkownika."
+
+msgid "COMMENTING_ENABLED_AFTER_UNBLOCK"
+msgstr "Po zablokowaniu tego użytkownika, będą znowu mogli komentować twoje Flipnotes, chyba że on również cię zablokował."
+
+msgid "UNBLOCK_WARNING_ONE_DAY_THRESHOLD"
+msgstr "Jeżeli go odblokujesz, będziesz musiał czekać 24 godziny zanim możliwe będzie jego ponowne zablokowanie."
+
+msgid "CONFIRM_UNBLOCK"
+msgstr "Potwierdź odblokowanie"
+
+msgid "RECENTLY_UNBLOCKED_ONE_DAY_THRESHOLD"
+msgstr "Niedawno odblokowałeś tego użytkownika. Musisz poczekać 24 godziny zanim możliwe będzie jego ponowne zablokowanie."

--- a/pl_PL/LC_MESSAGES/browseChannel.po
+++ b/pl_PL/LC_MESSAGES/browseChannel.po
@@ -1,0 +1,20 @@
+msgid "UPPERTITLE"
+msgstr "Przeglądaj kanał"
+
+msgid "POST_FLIPNOTE"
+msgstr "Wyślij Flipnote"
+
+msgid "NEXT"
+msgstr "Następna"
+
+msgid "PREV"
+msgstr "Poprzednia"
+
+msgid "PAGE"
+msgstr "Strona"
+
+msgid "PAGE_COUNTER_FORMAT"
+msgstr "%d z %d"
+
+msgid "SPINOFFS"
+msgstr "Spinoff-y"

--- a/pl_PL/LC_MESSAGES/browseFlipnotes.po
+++ b/pl_PL/LC_MESSAGES/browseFlipnotes.po
@@ -1,0 +1,65 @@
+msgid "SUDOMEMO"
+msgstr "Sudomemo"
+
+msgid "HEADER_FLIPNOTES"
+msgstr "Flipnotes"
+
+msgid "HEADER_NORMAL"
+msgstr "Najnowsze"
+
+msgid "HEADER_HOT_FLIPNOTES"
+msgstr "Gorące Flipnotes"
+
+msgid "HEADER_MOST_POPULAR"
+msgstr "Najbardziej popularne"
+
+msgid "HEADER_NO_SPINOFFS"
+msgstr "Bez spin-offów"
+
+msgid "HEADER_ROLEPLAYS"
+msgstr "Roleplay"
+
+msgid "HEADER_BROWSE_FLIPNOTES"
+msgstr "Przeglądaj Flipnotes"
+
+msgid "HEADER_FEATURED_FLIPNOTES"
+msgstr "Wyróżnione Flipnotes"
+
+msgid "HEADER_RANDOM_FLIPNOTES"
+msgstr "Losowe Flipnotes"
+
+msgid "HEADER_PAGE"
+msgstr "Strona"
+
+msgid "PAGE"
+msgstr "Strona"
+
+msgid "PAGE_COUNTER_FORMAT"
+msgstr "%d z %d"
+
+msgid "NEXT"
+msgstr "Następna"
+
+msgid "PREV"
+msgstr "Poprzednia"
+
+msgid "POST_FLIPNOTE"
+msgstr "Wyślij Flipnote"
+
+msgid "CATEGORY_recent"
+msgstr "@Najnowsze Flipnotes"
+
+msgid "CATEGORY_hot"
+msgstr "@Gorące Flipnotes"
+
+msgid "CATEGORY_popular"
+msgstr "@Najbardziej popularne"
+
+msgid "CATEGORY_featured"
+msgstr "@Wyróżnione Flipnotes"
+
+msgid "CATEGORY_random"
+msgstr "@Losowe Flipnotes"
+
+msgid "CATEGORY_feed"
+msgstr "@Kanał"

--- a/pl_PL/LC_MESSAGES/channelCategories.po
+++ b/pl_PL/LC_MESSAGES/channelCategories.po
@@ -1,0 +1,26 @@
+msgid "UPPERTITLE"
+msgstr "Kategorie"
+
+msgid "ART"
+msgstr "Sztuka"
+
+msgid "GENRES"
+msgstr "Rodzaje"
+
+msgid "TOPICS"
+msgstr "Tematy"
+
+msgid "ROLEPLAYS"
+msgstr "Roleplay"
+
+msgid "FANDOMS"
+msgstr "Fandom"
+
+msgid "RESOURCES"
+msgstr "Zasoby"
+
+msgid "PERSONAL"
+msgstr "Osobiste"
+
+msgid "WEEKLY_TOPICS"
+msgstr "Cotygodniowe Tematy"

--- a/pl_PL/LC_MESSAGES/channelDetails.po
+++ b/pl_PL/LC_MESSAGES/channelDetails.po
@@ -1,0 +1,38 @@
+msgid "CHANNEL_NAME"
+msgstr "Nazwa kanału"
+
+msgid "CHANNEL_INFORMATION"
+msgstr "Informacje o kanale"
+
+msgid "FLIPNOTES"
+msgstr "Flipnotes"
+
+msgid "CHANNEL_ID"
+msgstr "ID kanału"
+
+msgid "LOGIN_REQUIRED_TO_POST"
+msgstr "Musisz się zalogować by wysyłać Flipnotes."
+
+msgid "CHANNEL_NOT_SPECIFIED"
+msgstr "Musisz wybrać kanał."
+
+msgid "FLIPNOTE_POST_FAIL_USER_BANNED"
+msgstr "Twoje konto Sudomemo zostało zawieszone."
+
+msgid "FLIPNOTE_POST_FAILED"
+msgstr "Wysyłanie Flipnote nie powiodło się."
+
+msgid "DUPLICATE_FLIPNOTE_FAILED"
+msgstr "Ten Flipnote został już wysłany na Sudomemo. Spróbuj zmodyfikować go ponownie."
+
+msgid "FLIPNOTE_DATA_CORRUPTED"
+msgstr "Dane tego Flipnote zostały uszkodzone. Spróbuj ponownie za kilka minut."
+
+msgid "NO_BLANK_FLIPNOTES_ALLOWED"
+msgstr "Nie możesz wysłać pustego Flipnote."
+
+msgid "CONFIRM_EMAIL_BEFORE_POSTING"
+msgstr "Potwierdź swój adres e-mail przed wysłaniem."
+
+msgid "NO_POSTS_WHILE_MUTED"
+msgstr "Nie możesz wysłać Flipnote kiedy jesteś wyciszony."

--- a/pl_PL/LC_MESSAGES/channelList.po
+++ b/pl_PL/LC_MESSAGES/channelList.po
@@ -1,0 +1,20 @@
+msgid "UPPERTITLE"
+msgstr "Kanały"
+
+msgid "UPPERSUBBOTTOM"
+msgstr "Proszę wybrać kanał!"
+
+msgid "NEXT"
+msgstr "Następna strona"
+
+msgid "PREV"
+msgstr "Poprzednia strona"
+
+msgid "FAVORITES"
+msgstr "Ulubione"
+
+msgid "PAGE"
+msgstr "Strona"
+
+msgid "PAGE_COUNTER_FORMAT"
+msgstr "%d z %d"

--- a/pl_PL/LC_MESSAGES/chatrooms.po
+++ b/pl_PL/LC_MESSAGES/chatrooms.po
@@ -1,0 +1,44 @@
+msgid "NO_COMMENTS_YET"
+msgstr "Żadne wiadomości nie zostały jeszcze przesłane."
+
+msgid "HEADER_COMMENTS"
+msgstr "Komentarze"
+
+msgid "PAGE_FORMAT"
+msgstr "Strona %d"
+
+msgid "HEADER_NEXT"
+msgstr "Następna"
+
+msgid "HEADER_PREV"
+msgstr "Poprzednia"
+
+msgid "HEADER_REFRESH"
+msgstr "Odśwież"
+
+msgid "LOGIN_REQUIRED_TO_POST_CHAT_MESSAGE"
+msgstr "Musisz się zalogować żeby wysłać wiadomość."
+
+msgid "CHAT_REPLY_FAILED"
+msgstr "Wysyłanie odpowiedzi nie powiodło się. Spróbuj ponownie później."
+
+msgid "NO_BLANK_MESSAGES_ALLOWED"
+msgstr "Nie możesz wysłać pustej wiadomości."
+
+msgid "FLIPNOTE_DATA_CORRUPTED"
+msgstr "Dane tego Flipnote zostały uszkodzone. Spróbuj ponownie za kilka minut."
+
+msgid "NO_CHAT_MESSAGES_WHILE_MUTED"
+msgstr "Zostałeś wyciszony. Nie możesz czatować."
+
+msgid "DUPLICATE_COMMENT_FAILED"
+msgstr "Ten komentarz został już wysłano do Sudomemo."
+
+msgid "COMMENT_FAILED_USER_BANNED"
+msgstr "Twoja możliwość interakcji z Sudomemo została zawieszona."
+
+msgid "CONFIRM_EMAIL_BEFORE_POSTING"
+msgstr "Potwierdź swój adres e-mail przed wysłaniem."
+
+msgid "MODERATOR"
+msgstr "Moderator"

--- a/pl_PL/LC_MESSAGES/colorPicker.po
+++ b/pl_PL/LC_MESSAGES/colorPicker.po
@@ -1,0 +1,17 @@
+msgid "SET_PEN_COLOR"
+msgstr "Ustaw kolor długopisu"
+
+msgid "SET_PAPER_COLOR"
+msgstr "Ustaw kolor papieru"
+
+msgid "SELECT_A_COLOR"
+msgstr "Wybierz kolor."
+
+msgid "CURRENT_COLOR"
+msgstr "Aktualny kolor:"
+
+msgid "CURRENT_COLOR_DEFAULT"
+msgstr "Aktualny kolor: domyślny"
+
+msgid "RETURN"
+msgstr "Wróć"

--- a/pl_PL/LC_MESSAGES/commentDetails.po
+++ b/pl_PL/LC_MESSAGES/commentDetails.po
@@ -1,0 +1,41 @@
+msgid "COMMENT_DETAILS"
+msgstr "Informacje o komentarzu"
+
+msgid "MESSAGE_DETAILS"
+msgstr "Informacje o wiadomości"
+
+msgid "AUTHOR"
+msgstr "Autor"
+
+msgid "COMMENT_BY_FORMAT"
+msgstr "Komentarz %s"
+
+msgid "CHAT_MESSAGE_FROM_FORMAT"
+msgstr "Wiadomość na czacie od %s"
+
+msgid "MESSAGE_FROM_FORMAT"
+msgstr "Wiadomość od %s"
+
+msgid "FLIPNOTE_BY_FORMAT"
+msgstr "Flipnote stworzony przez %s"
+
+msgid "COMMENT_ID"
+msgstr "ID komentarza"
+
+msgid "MESSAGE_ID"
+msgstr "ID wiadomości"
+
+msgid "CHAT_COMMENT_ID"
+msgstr "ID komentarza na czacie"
+
+msgid "TIMESTAMP"
+msgstr "Data"
+
+msgid "POSTED_TO"
+msgstr "Wysłane do"
+
+msgid "PRIVATE_CONVERSATION"
+msgstr "Prywatna konwersacja"
+
+msgid "REPORT_CONTENT"
+msgstr "Zgłoś zawartość"

--- a/pl_PL/LC_MESSAGES/commonEmailStrings.po
+++ b/pl_PL/LC_MESSAGES/commonEmailStrings.po
@@ -1,0 +1,8 @@
+msgid "TEXT_CHANGE_SETTINGS_PROMPT"
+msgstr "Chcesz zmienić to, jakie e-maile dostajesz od Sudomemo?"
+
+msgid "TEXT_HOW_TO_CHANGE_SETTINGS_DSI"
+msgstr "Możesz to łatwo zmienić, wchodząc do twojego Pokoju Twórcy na Sudomemo i wybierając <strong>Ustawienia e-maila</strong>."
+
+msgid "TEXT_WEB_SETTINGS_CHANGE_FORMAT"
+msgstr "Alternatywnie, możesz wyłączyć tego typu maile klikając <a target=\"_blank\" href=\"%s\"><strong>tutaj</strong></a>."

--- a/pl_PL/LC_MESSAGES/creatorsRoom.po
+++ b/pl_PL/LC_MESSAGES/creatorsRoom.po
@@ -1,0 +1,206 @@
+msgid "SEE_MORE"
+msgstr "Zobacz więcej..."
+
+msgid "STARRED_FLIPNOTES"
+msgstr "Starred Flipnotes"
+
+msgid "FAVORITE_USERS"
+msgstr "Ulubieni użytkownicy"
+
+msgid "FAVORITES_FEED"
+msgstr "Strumień ulubionych"
+
+msgid "FAVORITE_CHANNELS"
+msgstr "Ulubione kanały"
+
+msgid "USER_DOWNLOADCOUNT"
+msgstr "Pobrania"
+
+msgid "USER_VIEWCOUNT"
+msgstr "Wyświetlenia"
+
+msgid "USER_THEME"
+msgstr "Motyw"
+
+msgid "THEME_SHOP"
+msgstr "Sklep z motywami"
+
+msgid "POSTED_COMMENTS"
+msgstr "Wysłane komentarze"
+
+msgid "POSTED_CHATCOMMENTS"
+msgstr "Wiadomości na czacie"
+
+msgid "FEATURE_USABILITY"
+msgstr "Feature Usability"
+
+msgid "USABLE"
+msgstr "Usable"
+
+msgid "NOT_USABLE"
+msgstr "Not Usable"
+
+msgid "SUDOMEMO_THEATRE_URL"
+msgstr "Link na Sudomemo Theatre"
+
+msgid "FLIPNOTE_STUDIO_ID"
+msgstr "ID Flipnote Studio"
+
+msgid "SETTINGS"
+msgstr "Ustawienia"
+
+msgid "ADMIN_ACCT_GOOD_STANDING"
+msgstr "W dobrym stanie"
+
+msgid "ADMIN_ACCT_BANNED"
+msgstr "Zbanowany"
+
+msgid "ADMIN_ACCT_BLOCKED"
+msgstr "Zablokowany"
+
+msgid "ADMIN_ACCT_MUTED"
+msgstr "Wyciszony"
+
+msgid "ADMIN_USER_DETAILS"
+msgstr "Informacje o użytkowniku"
+
+msgid "ADMIN_LAST_SEEN"
+msgstr "Ostatnio widziany"
+
+msgid "ADMIN_USER_STATUS"
+msgstr "Status użytkownika"
+
+msgid "ADMIN_ADMINISTRATIVE_ACTIONS"
+msgstr "Akcje administracyjne"
+
+msgid "BLOCK_COMMENTS_HEADER"
+msgstr "Zablokuj komentarze"
+
+msgid "BLOCK_COMMENTS_LINK"
+msgstr "Zablokuj"
+
+msgid "USABILITY_USABLE"
+msgstr "Usable"
+
+msgid "USABILITY_NOT_USABLE"
+msgstr "Not Usable"
+
+msgid "HEADER_FOLLOWERS"
+msgstr "Obserwujący"
+
+msgid "HEADER_FOLLOWING"
+msgstr "Obserwowani"
+
+msgid "PREVIOUS"
+msgstr "Poprzednia"
+
+msgid "NEXT"
+msgstr "Następna"
+
+msgid "CHANGE_ROOM_THEME_LINK"
+msgstr "[zmień motyw]"
+
+msgid "SELECT_THEME"
+msgstr "Wybierz motyw"
+
+msgid "FANS"
+msgstr "Fani"
+
+msgid "EXAMPLE"
+msgstr "Przykład"
+
+msgid "THEMETEST_SET_THEME"
+msgstr "Ustaw motyw"
+
+msgid "THEMETEST_NOTICE"
+msgstr "Uwaga"
+
+msgid "THEMETEST_OK"
+msgstr "OK"
+
+msgid "THEMETEST_ERROR"
+msgstr "Błąd"
+
+msgid "THEMETEST_NOTICE_2"
+msgstr "Uwaga #2"
+
+msgid "THEMETEST_ACTIVE_TAB"
+msgstr "Aktywna zakładka"
+
+msgid "THEMETEST_INACTIVE_TAB"
+msgstr "Nieaktywna zakładka"
+
+msgid "PREVIEW"
+msgstr "Podgląd"
+
+msgid "CREATORS_ROOM"
+msgstr "Pokój Twórcy"
+
+msgid "THEME_ERROR_THEME_NOT_OWNED"
+msgstr "Przepraszamy! Nie posiadasz tego motywu."
+
+msgid "THEME_SUCCESSFULLY_SET"
+msgstr "Ustawianie motywu powiodło się!"
+
+msgid "BLOCKED_USERS"
+msgstr "Zablokowani użytkownicy"
+
+msgid "VIEW"
+msgstr "Pokać"
+
+msgid "FAN_COUNT_FORMAT"
+msgstr "Fani: %s"
+
+msgid "HEADER_LANGUAGE"
+msgstr "Język"
+
+msgid "HEADER_MAIL_SETTINGS"
+msgstr "Ustawienia e-maila"
+
+msgid "HEADER_EDIT_BIOGRAPHY"
+msgstr "Edytuj biografię"
+
+msgid "SET_BIO_INSTRUCTIONS"
+msgstr "Wpisz biografię profilu poniżej. Będzie ona wyświetlana na Sudomemo i Sudomemo Theatre."
+
+msgid "ENTER_BIO"
+msgstr "Wpisz biografię..."
+
+msgid "101_CHARACTER_LIMIT_BIO"
+msgstr "Twoja biografia ma limit 101 znaków."
+
+msgid "LEAVE_BLANK_TO_RESET_BIO"
+msgstr "Żeby wyczyścić biografię, zostaw ten formularz pusty podczas wysyłania."
+
+msgid "CURRENT_BIO"
+msgstr "Aktualna biografia:"
+
+msgid "FOLLOW_LIMIT_EXCEEDED_FORMAT"
+msgstr "Nie możesz obserwować więcej niż %d osób."
+
+msgid "RANKING"
+msgstr "Ranking"
+
+msgid "TICKET_SECTION"
+msgstr "Losy"
+
+msgid "DRAW_REGULAR_TICKET"
+msgstr "Los"
+
+msgid "CAN_DRAW_TICKET_SUBTEXT"
+msgstr "Możesz użyć zwyczajnego losu! Możesz wygrać nagrodę."
+
+msgid "INVENTORY"
+msgstr "Ekwipunek"
+
+msgid "TICKET_COOLDOWN_MESSAGE_FORMAT"
+msgstr "Możesz użyć kolejnego losu za: %s godzin(y) %s minut(y)."
+
+msgid "REDEEM"
+msgstr "Użyj"
+
+msgid "SPENDABLE_STARS"
+msgstr "Twoje gwiazdki"
+
+msgid "SPENDABLE_STARS_HELPTEXT"
+msgstr "Gwiazdki które możesz dodać do Flipnotes lub użyć do motywów"

--- a/pl_PL/LC_MESSAGES/creatorsRoom.po
+++ b/pl_PL/LC_MESSAGES/creatorsRoom.po
@@ -204,3 +204,12 @@ msgstr "Twoje gwiazdki"
 
 msgid "SPENDABLE_STARS_HELPTEXT"
 msgstr "Gwiazdki które możesz dodać do Flipnotes lub użyć do motywów"
+
+msgid "LOGIN_REQUIRED_ACTION"
+msgstr "Musisz się zalogować by wykonać tę operację."
+
+msgid "PAGE"
+msgstr "Strona"
+
+msgid "PAGE_COUNTER_FORMAT"
+msgstr "%d z %d"

--- a/pl_PL/LC_MESSAGES/dailyStarReport.po
+++ b/pl_PL/LC_MESSAGES/dailyStarReport.po
@@ -1,0 +1,20 @@
+msgid "EMAIL_SUBJECT_FORMAT"
+msgstr "[Sudomemo] %s's Codzienny reportaż gwiazdek"
+
+msgid "STRING_SUDOMEMO"
+msgstr "Sudomemo"
+
+msgid "STRING_DAILY_STAR_REPORT"
+msgstr "Codzienny reportaż gwiazdek"
+
+msgid "TEXT_STAR_REPORT_GREETING_FORMAT"
+msgstr "Witaj, %s! To jest twój codzienny reportaż gwiazdek od Sudomemo"
+
+msgid "TEXT_FLIPNOTE_BY_FORMAT"
+msgstr "Flipnote stworzony przez %s"
+
+msgid "TEXT_TOTAL_STARS_RECEIVED_TODAY"
+msgstr "Suma gwiazdek otrzymanych dziś:"
+
+msgid "TEXT_HOW_TO_VIEW_STAR_ADDERS_DSI"
+msgstr "Używając twojej konsoli Nintendo DSi, możesz zobaczyć kto dodał gwiazdki klikając na <strong>Gwiazdki</strong> na stronie z informacjami o twoim Flipnote na Sudomemo."

--- a/pl_PL/LC_MESSAGES/detailsPage.po
+++ b/pl_PL/LC_MESSAGES/detailsPage.po
@@ -20,7 +20,7 @@ msgid "HEADER_NO_STARBEGGING_STAR_LIMIT"
 msgstr "Żeby zapobiec naciąganiu na gwiazdki, żółte gwiazdki są limitowane na 10 na Flipnote."
 
 msgid "HEADER_CREATOR"
-msgstr "Twórca
+msgstr "Twórca"
 
 msgid "HEADER_STARS"
 msgstr "Gwiazdki"

--- a/pl_PL/LC_MESSAGES/detailsPage.po
+++ b/pl_PL/LC_MESSAGES/detailsPage.po
@@ -1,0 +1,107 @@
+msgid "TIMESTAMP_FORMAT"
+msgstr "d M Y H:i:s"
+
+msgid "FLIPNOTE_TITLE_FORMAT"
+msgstr "Flipnote stworzony przez %s"
+
+msgid "HEADER_DETAILS"
+msgstr "Informacje"
+
+msgid "HEADER_COMMENTS"
+msgstr "Komentarze"
+
+msgid "HEADER_THIS_FLIPNOTE_IS_A_SPINOFF"
+msgstr "Ten Flipnote jest spin-offem."
+
+msgid "HEADER_ORIGINAL_FLIPNOTE"
+msgstr "Zobacz orginalny Flipnote tutaj"
+
+msgid "HEADER_NO_STARBEGGING_STAR_LIMIT"
+msgstr "Żeby zapobiec naciąganiu na gwiazdki, żółte gwiazdki są limitowane na 10 na Flipnote."
+
+msgid "HEADER_CREATOR"
+msgstr "Twórca
+
+msgid "HEADER_STARS"
+msgstr "Gwiazdki"
+
+msgid "HEADER_VIEWS"
+msgstr "Wyświetlenia"
+
+msgid "HEADER_SPINOFFS"
+msgstr "Spin-offy"
+
+msgid "HEADER_DOWNLOADS"
+msgstr "Pobrania"
+
+msgid "HEADER_TITLE"
+msgstr "Tytuł"
+
+msgid "HEADER_POSTED"
+msgstr "Wysłany"
+
+msgid "HEADER_FLIPNOTE_ID"
+msgstr "ID Flipnote"
+
+msgid "HEADER_CHANNEL"
+msgstr "Kanał"
+
+msgid "HEADER_OPTIONS"
+msgstr "Opcje"
+
+msgid "HEADER_SET_AS_PROFILE_PICTURE"
+msgstr "Ustaw jako zdjęcie profilowe"
+
+msgid "HEADER_REPORT_FLIPNOTE"
+msgstr "Zgłoś Flipnote"
+
+msgid "ADMIN_ACTIONS"
+msgstr "Akcje administracyjne"
+
+msgid "PREV"
+msgstr "Poprzednia"
+
+msgid "NEXT"
+msgstr "Następna"
+
+msgid "STAR_DETAILS_UPPERTITLE"
+msgstr "★ Gwiazdki ★"
+
+msgid "SET_TITLE"
+msgstr "Ustaw tytuł"
+
+msgid "SET_TITLE_INSTRUCTIONS"
+msgstr "Wpisz nowy tytuł dla twojego Flipnote poniżej."
+
+msgid "40_CHARACTER_LIMIT"
+msgstr "Twój tytuł może mieć długość max. 40 znaków."
+
+msgid "LEAVE_BLANK_TO_RESET"
+msgstr "Żeby zresetować tytuł do domyślnego, zostaw ten formularz pusty podczas wysyłania."
+
+msgid "ENTER_TITLE"
+msgstr "Wpisz tytuł..."
+
+msgid "HEADER_ADD_DESCRIPTION"
+msgstr "Dodaj opis"
+
+msgid "HEADER_DESCRIPTION"
+msgstr "Opis"
+
+msgid "SET_DESCRIPTION"
+msgstr "Ustaw opis"
+
+msgid "SET_DESCRIPTION_INSTRUCTIONS"
+msgstr "Wpisz nowy opis dla twojego Flipnote poniżej."
+
+msgid "101_CHARACTER_LIMIT_DESC"
+msgstr "Twój opis może mieć długość max. 101 znaków."
+
+msgid "LEAVE_BLANK_TO_RESET_DESC"
+msgstr "Żeby usunąć opis, zostaw ten formularz pusty podczas wysyłania."
+
+msgid "ENTER_DESCRIPTION"
+msgstr "Wpisz opis..."
+
+msgid "HEADER_FLIPNOTE_OPTIONS"
+msgstr "Opcje"

--- a/pl_PL/LC_MESSAGES/emailVerificationReminder.po
+++ b/pl_PL/LC_MESSAGES/emailVerificationReminder.po
@@ -1,0 +1,17 @@
+msgid "EMAIL_SUBJECT"
+msgstr "[Sudomemo] Musisz zweryfikować swój adres e-mail"
+
+msgid "VERIFICATION_HEADER"
+msgstr "Sudomemo - Zwerywikuj e-mail"
+
+msgid "TEXT_HELLO_FORMAT"
+msgstr "Witaj, %s!"
+
+msgid "TEXT_NEED_TO_VERIFY_EMAIL"
+msgstr "Przypominamy, że musisz zweryfikować swój adres e-mail na Sudomemo."
+
+msgid "TEXT_LOGIN_WITH_DSI_TO_VERIFY"
+msgstr "Możesz otrzymać nowy e-mail weryfikacyjny logując się do Sudomemo przez twoją konsolę Nintendo DSi."
+
+msgid "TEXT_NEED_HELP_CONNECTION_INFO_LINK_FORMAT"
+msgstr "Potrzebujesz pomocy w łączeniu się z Sudomemo? Poradnik ustawiania konsoli znajdziesz tutaj: %s"

--- a/pl_PL/LC_MESSAGES/flipnoteComments.po
+++ b/pl_PL/LC_MESSAGES/flipnoteComments.po
@@ -1,0 +1,50 @@
+msgid "HEADER_COMMENTS"
+msgstr "Komentarze"
+
+msgid "HEADER_DETAILS"
+msgstr "Informacje"
+
+msgid "HEADER_PREV"
+msgstr "Poprzednia"
+
+msgid "HEADER_NEXT"
+msgstr "Następna"
+
+msgid "HEADER_REFRESH"
+msgstr "Odśwież"
+
+msgid "PAGE_FORMAT"
+msgstr "Strona %d"
+
+msgid "NO_COMMENTS_YET"
+msgstr "Ten Flipnote nie ma jeszcze żadnych komentarzy."
+
+msgid "LOGIN_REQUIRED_TO_POST_COMMENT"
+msgstr "Musisz się zalogować by wysłać komentarz."
+
+msgid "COMMENT_POST_FAILED"
+msgstr "Wysłanie komentarza nie powiodło się. Spróbuj ponownie później."
+
+msgid "NO_BLANK_COMMENTS_ALLOWED"
+msgstr "Nie możesz wysłać pustego komentarza."
+
+msgid "FLIPNOTE_DATA_CORRUPTED"
+msgstr "Dane tego Flipnote są uszkodzone. Spróbuj ponownie później."
+
+msgid "FLIPNOTE_COMMENTS_DISALLOWED"
+msgstr "Nie możesz komentować na tym Flipnote."
+
+msgid "NO_COMMENTS_WHILE_MUTED"
+msgstr "Zostałeś wyciszony. Nie możesz komentować."
+
+msgid "DUPLICATE_COMMENT_FAILED"
+msgstr "Ten komentarz został już wysłany na Sudomemo."
+
+msgid "COMMENT_FAILED_USER_BANNED"
+msgstr "Twoja możliwość interakcji z Sudomemo została zawieszona."
+
+msgid "CONFIRM_EMAIL_BEFORE_POSTING"
+msgstr "Potwierdź swój e-mail przed wysłaniem."
+
+msgid "MODERATOR"
+msgstr "Moderator"

--- a/pl_PL/LC_MESSAGES/flipnoteOptions.po
+++ b/pl_PL/LC_MESSAGES/flipnoteOptions.po
@@ -1,0 +1,53 @@
+msgid "FLIPNOTE_OPTIONS"
+msgstr "Opcje Flipnota"
+
+msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
+msgstr "Musisz się zalogować by wyświetlić tą stronę."
+
+msgid "HEADER_OPTION"
+msgstr "Opcja"
+
+msgid "HEADER_STATUS"
+msgstr "Status"
+
+msgid "OPTION_NAME_SMOOTH"
+msgstr "Wygładzanie"
+
+msgid "OPTION_DESC_SMOOTH"
+msgstr "Linie, wygięcia i kanty są wygładzone dla bardziej naturalnego wyglądu na Sudomemo Theatre."
+
+msgid "FLIPNOTE_URL_IS"
+msgstr "Link do Flipnote:"
+
+msgid "ENABLE_SMOOTHING"
+msgstr "Włącz wygładzanie"
+
+msgid "DISABLE_SMOOTHING"
+msgstr "Wyłącz wygładzanie"
+
+msgid "ON"
+msgstr "Włączone"
+
+msgid "OFF"
+msgstr "Wyłączone"
+
+msgid "CITIZENSHIP_REQUIRED"
+msgstr "Potrzebujesz Sudomemo Citizenship by używać tej funkcji."
+
+msgid "PLUS_REQUIRED"
+msgstr "Potrzebujesz Sudomemo Plus by używać tej funkcji."
+
+msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
+msgstr "Kliknij na status opcji by go wyświetlić lub zmienić."
+
+msgid "OPTION_NAME_FORCE_44K_BITRATE"
+msgstr "Ulepszenie dźwięku"
+
+msgid "OPTION_DESC_FORCE_44K_BITRATE"
+msgstr "Sudomemo spróbuje ulepszyć dźwięk twojego Flipnote na Sudomemo Theatre."
+
+msgid "ENABLE_AUDIO_ENHANCEMENT"
+msgstr "Włącz ulepszenie dźwięku"
+
+msgid "DISABLE_AUDIO_ENHANCEMENT"
+msgstr "Wyłącz ulepszenie dźwięku"

--- a/pl_PL/LC_MESSAGES/followNotificationEmail.po
+++ b/pl_PL/LC_MESSAGES/followNotificationEmail.po
@@ -1,0 +1,23 @@
+msgid "EMAIL_SUBJECT_FORMAT"
+msgstr "[Sudomemo] %s dodał cię do swoich Ulubionych"
+
+msgid "GREETING_FORMAT"
+msgstr "Cześć %s!"
+
+msgid "NEW_FOLLOWER_ADDED_YOU_FORMAT"
+msgstr "%s właśnie dodał cię do swoich Ulubionych."
+
+msgid "STATS_FLIPNOTES_FORMAT"
+msgstr "%s Flipnotes"
+
+msgid "STATS_FOLLOWERS_FORMAT"
+msgstr "%s Obserwujących"
+
+msgid "STATS_FLIPNOTES_FORMAT_SINGULAR"
+msgstr "%s Flipnote"
+
+msgid "STATS_FOLLOWERS_FORMAT_SINGULAR"
+msgstr "%s Obserwujący"
+
+msgid "VIEW_PROFILE"
+msgstr "Pokaż profil"

--- a/pl_PL/LC_MESSAGES/happyBirthdayEmail.po
+++ b/pl_PL/LC_MESSAGES/happyBirthdayEmail.po
@@ -1,0 +1,14 @@
+msgid "EMAIL_SUBJECT_FORMAT"
+msgstr "[Sudomemo] Sto lat, %s!"
+
+msgid "GREETING_FORMAT"
+msgstr "Cześć %s!"
+
+msgid "HAPPY_BIRTHDAY"
+msgstr "Życzymy Ci sto lat!"
+
+msgid "SPECIAL_SURPRISE_WAITING"
+msgstr "Na Sudomemo czeka na ciebie specjalna urodzinowa niespodzianka."
+
+msgid "LOGON_ON_DS_TO_VIEW"
+msgstr "Zaloguj się do Sudomemo na twojej konsoli Nintendo DSi lub 3DS żeby odebrać swój urodzinowy prezent!"

--- a/pl_PL/LC_MESSAGES/inbox.po
+++ b/pl_PL/LC_MESSAGES/inbox.po
@@ -1,0 +1,12 @@
+msgid "HEADER_INBOX"
+msgstr "Skrzynka pocztowa"
+
+# this must be a max of 6 characters
+msgid "UNAUTHED_READ"
+msgstr "Czytaj"
+
+msgid "PREV"
+msgstr "Poprzednia"
+
+msgid "NEXT"
+msgstr "Następna"

--- a/pl_PL/LC_MESSAGES/localeSelection.po
+++ b/pl_PL/LC_MESSAGES/localeSelection.po
@@ -1,0 +1,17 @@
+msgid "CHANGE_LANGUAGE"
+msgstr "Zmień język"
+
+msgid "LANGUAGE_UPDATED_FORMAT"
+msgstr "Twój język został zmieniony na %s."
+
+msgid "POTENTIAL_CONTRIBUTOR_NOTE"
+msgstr "Sudomemo opiera się na swojej społeczności by otrzymać dokładne tłumaczenia. Jeżeli zauważysz coś, co nie wyświetla się poprawnie, dalej wyświetla się po angielsku, jest tłumaczeniem o niskiej jakości lub jeśli chcesz dodać własny język, zachęcamy do pomocy! Pełne i zweryfikowane tłumaczenia mogą dać ci dodatkowe dni Sudomemo Plus. Możesz dopomóc tutaj: https://github.com/Sudomemo/sudomemo-locales"
+
+msgid "RETURN_TO_CREATORS_ROOM"
+msgstr "Wróć do Pokoju Twórcy"
+
+msgid "NOT_LOGGED_IN"
+msgstr "Musisz się zalogować zanim zmienisz swój język."
+
+msgid "INVALID_LOCALE"
+msgstr "Przepraszamy, ale ten język nie jest dostępny."

--- a/pl_PL/LC_MESSAGES/login.po
+++ b/pl_PL/LC_MESSAGES/login.po
@@ -1,0 +1,245 @@
+msgid "BAN_GREETING_FORMAT"
+msgstr "Witaj, %s."
+
+msgid "BAN_NOTICE_CONSOLE_BAN"
+msgstr "Twoje konto i konsola zostały zbanowane z Sudomemo."
+
+msgid "BAN_NOTICE_PLEASE_READ_BAN_LETTER"
+msgstr "Przeczytaj list który ci wysłaliśmy by znaleźć więcej informacji."
+
+msgid "BAN_VIEW_MAIL"
+msgstr "Przejdź do skrzynki mailowej"
+
+msgid "LOGIN_SUCCESSFUL"
+msgstr "Logowanie się powiodło"
+
+msgid "THANKS_FOR_LOGIN_FORMAT"
+msgstr "Dziękujemy za zalogowanie się, %s!"
+
+msgid "GOTO_CREATORS_ROOM"
+msgstr "Przejdź do swojego Pokoju Twórcy"
+
+msgid "LOGIN"
+msgstr "Zaloguj się"
+
+msgid "POST_COMMENT_BELOW"
+msgstr "Żeby kontynuować, wyślij komentarz poniżej."
+
+msgid "LOGIN_SETUP"
+msgstr "Ustawienia logowania"
+
+msgid "WELCOME_BACK_FORMAT"
+msgstr "Witaj z powrotem, %s!"
+
+msgid "RETURNING_USER_NEW_LOGIN_SYSTEM"
+msgstr "Od twojej ostatniej wizyty, zmieniliśmy nasz system logowania -- ale nie martw się, twoja zawartosć wciąż tu jest!"
+
+msgid "RETURNING_USER_PLEASE_CREATE_PASSWORD"
+msgstr "Żeby rozpocząć, wpisz nowe hasło poniżej."
+
+msgid "NEW_USER_WELCOME_FORMAT"
+msgstr "Witaj w Sudomemo, %s!"
+
+msgid "NEW_USER_PLEASE_CREATE_PASSWORD"
+msgstr "Stwórz nowe hasło."
+
+msgid "FORM_HEADER_PASSWORD"
+msgstr "Hasło:"
+
+msgid "FORM_PREFILL_PASSWORD"
+msgstr "Wpisz swoje hasło..."
+
+msgid "FORM_WARNING_PASSWORD_TOO_SHORT"
+msgstr "Wpisz hasło które ma więcej niż 8 znaków."
+
+msgid "FORM_WARNING_PASSWORD_DISALLOWED_CHARS"
+msgstr "Twoje hasło nie może zawierać znaków:"
+
+msgid "FORM_LABEL_DONT_FORGET_PASSWORD"
+msgstr "Pamiętaj żeby zanotować swoje hasło, i przechowywać je bezpiecznie!"
+
+msgid "FORM_HEADER_EMAIL"
+msgstr "E-mail:"
+
+msgid "FORM_PREFILL_EMAIL"
+msgstr "Wpisz tutaj swój e-mail..."
+
+msgid "FORM_WARNING_EMAIL_INVALID"
+msgstr "Adres e-mail, który wprowadziłeś, jest niepoprawny."
+
+msgid "EMAIL_ADDITION_SUGGESTED"
+msgstr "E-mail jest opcjonalny, ale bardzo przydatny. Jeżeli kiedykolwiek zapomnisz swojego hasła, wyślemy ci link do jego zresetowania na twój adres e-mail."
+
+msgid "EMAIL_ADDITION_DETAILS"
+msgstr "Jeżeli kiedykolwiek zapomnisz swojego hasła, wyślemy ci link do jego zresetowania na twój adres e-mail."
+
+msgid "CONFIRM_INFO_CORRECT"
+msgstr "Upewnij się, że informacje zawarte poniżej są prawidłowe."
+
+msgid "NO_PLAINTEXT_PASSWORD_RECOVERY_IF_LOST"
+msgstr "Po tym kroku nie będziemy mogli odzyskać twojego hasła jeśli je zgubisz."
+
+msgid "BUTTON_CHANGE_PASSWORD"
+msgstr "Zmień hasło"
+
+msgid "FORM_HEADER_EMAIL_CONFIRM"
+msgstr "E-mail:"
+
+msgid "BUTTON_CHANGE_EMAIL"
+msgstr "Zmień adres e-mail"
+
+msgid "BUTTON_ADD_AN_EMAIL_ADDRESS"
+msgstr "Dodaj adres e-mail"
+
+msgid "BUTTON_SUBMIT"
+msgstr "Wyślij"
+
+msgid "PLEASE_ENTER_PASSWORD_TO_SIGN_IN"
+msgstr "Wpisz swoje hasło by się zalogować"
+
+msgid "LOGIN_FORM_PREFILL_PASSWORD"
+msgstr "Wpisz hasło"
+
+msgid "INCORRECT_PASSWORD_ATTEMPTS_FORMAT"
+msgstr "Nieprawidłowe próby wpisania hasła: %s"
+
+msgid "REGISTRATION_ERROR_BAD_EMAIL"
+msgstr "Wprowadzony adres e-mail jest zabroniony."
+
+msgid "REGISTRATION_ERROR_BAD_PASSWORD"
+msgstr "Wprowadzone hasło jest zabronione."
+
+msgid "ERROR"
+msgstr "Błąd"
+
+msgid "REGISTRATION_ERROR_PASSWORD_ALREADY_SET"
+msgstr "Hasło zostało już ustawione."
+
+msgid "NEW_USER_THANKS_FOR_REGISTRATION"
+msgstr "Witaj w Sudomemo!"
+
+msgid "RETURNING_USER_THANKS_FOR_REGISTRATION"
+msgstr "Witaj z powrotem! Dziękujemy za ustawienie detali logowania."
+
+msgid "BUTTON_SIGN_IN_TO_SUDOMEMO"
+msgstr "Zaloguj się do Sudomemo"
+
+msgid "LOGIN_FAILED"
+msgstr "Logowanie nie powiodło się."
+
+msgid "LOGIN_FAILED_REOPEN_FLIPNOTE_STUDIO"
+msgstr "Logowanie nie powiodło się. Zamknij i otwórz ponownie Flipnote Studio."
+
+msgid "LOGIN_FAILED_CORRUPTED_DATA_LINE1"
+msgstr "Dane Flipnote są uszkodzone."
+
+msgid "LOGIN_FAILED_CORRUPTED_DATA_LINE2"
+msgstr "Spróbuj wysłać je ponownie."
+
+msgid "LOGIN_FAILED_BANNED_LINE1"
+msgstr "Twoje konto zostało zbanowane z Sudomemo."
+
+msgid "CONTACT_SUPPORT_EMAIL_FORMAT"
+msgstr "Proszę skontaktować się z %s."
+
+msgid "CREATORS_ROOM_SHIM_WELCOME"
+msgstr "Witaj!"
+
+msgid "CREATORS_ROOM_SHIM_PLEASE_LOGIN"
+msgstr "Witaj w Sudomemo! Zaloguj się by kontynuować."
+
+msgid "GUIDE_MAIN_MENU_SHORTCUT"
+msgstr "Możesz powrócić do głównego menu przytrzymując L (lub R jeśli jesteś leworęczny) i wciskając przycisk 'Menu'."
+
+msgid "SORRY_NO_LOGIN"
+msgstr "Przepraszamy, ale nie mogliśmy ciebie zalogować."
+
+msgid "BASIC_AUTH_NOT_ENABLED"
+msgstr "Nie włączyłeś podstawowej autentykacji w ustawieniach twojego proxy."
+
+msgid "BASIC_AUTH_FSID_INVALID"
+msgstr "ID Flipnote Studio które wpisałeś w podstawowej weryfikacji jest niepoprawne:"
+
+msgid "BASIC_AUTH_BAD_LENGTH_FORMAT"
+msgstr "ID ma %s cyfr (powinno być 6)"
+
+msgid "BASIC_AUTH_LOWERCASE_LETTERS"
+msgstr "ID zawiera małe litery - powinno zawierać jedynie duże."
+
+msgid "BASIC_AUTH_NONHEX_CHARACTERS"
+msgstr "ID zawiera znaki inne niż 0-9 i A-F (powinno zawierać jedynie 0-9 i A-F)."
+
+msgid "SEEK_LOGIN_HELP_IN_DISCORD_FORMAT"
+msgstr "Jeżeli potrzebujesz pomocy z łączeniem się, nie bój się zapytać na naszym Discordzie! Możesz dołączyć poprzez %s."
+
+msgid "BAN_NOTICE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Skontaktuj się z nami przez Discorda lub przez e-mail %s."
+
+msgid "FORGOT_PASSWORD_LINK"
+msgstr "Zapomniałeś hasła?"
+
+msgid "EMAIL_IS_DUPLICATE"
+msgstr "Wprowadzony adres e-mail jest już w użyciu."
+
+msgid "EMAIL_CONFIRMATION_SENT_FORMAT"
+msgstr "E-mail potwierdzający został wysłany do %s. Powinien pojawić się za kilka minut."
+
+msgid "BUTTON_CHECK_VERIFICATION"
+msgstr "Sprawdź status weryfikacji"
+
+msgid "EMAIL_NOT_YET_VERIFIED"
+msgstr "Twój adres e-mail nie został jeszcze zweryfikowany."
+
+msgid "EMAIL_VERIFIED"
+msgstr "Dziękujemy za zweryfikowanie adresu e-mail!"
+
+msgid "EMAIL_REQUIRES_UPDATE"
+msgstr "Twój adres e-mail musi być zaktualizowany."
+
+msgid "VERIFICATION_NEEDED"
+msgstr "Musisz zweryfikować swój adres e-mail."
+
+msgid "BUTTON_RESEND_VERIFICATION_EMAIL"
+msgstr "Wyślij e-mail weryfikujący ponownie"
+
+msgid "NOT_RECEIVING_HELP_FORMAT"
+msgstr "Nie dostajesz e-maila? Skontaktuj się z nami poprzez Discorda lub przez %s."
+
+msgid "HEADER_VERIFY_EMAIL"
+msgstr "Zweryfikuj adres e-mail"
+
+msgid "VERIFICATION_LIMIT_EXCEEDED_FORMAT"
+msgstr "Przekroczyłeś maksymalny limit e-maili weryfikujących. Skontaktuj się z nami poprzez %s oraz przez Discorda."
+
+msgid "WEB_HEADER_SUCCESS"
+msgstr "Sukces!"
+
+msgid "WEB_TAP_CHECK_VERIFICATION_STATUS"
+msgstr "Wciśnij 'Sprawdź status weryfikacji' na twojej konsoli Nintendo DSi żeby zakończyć weryfikację e-maila."
+
+msgid "HEADER_VERIFICATION_EXPIRED"
+msgstr "Weryfikacja wygasła"
+
+msgid "VERIFICATION_EXPIRED_TEXT"
+msgstr "Ten link weryfikacji wygasł lub został już użyty."
+
+msgid "CONTINUE_TO_LOGIN"
+msgstr "Kontynuuj do logowania"
+
+msgid "HEADER_UPDATE_EMAIL"
+msgstr "Aktualizuj e-mail"
+
+msgid "THANK_YOU_FOR_UPDATING_EMAIL"
+msgstr "Dziękujemy za zaktualizowanie e-maila!"
+
+msgid "BUTTON_CONTINUE"
+msgstr "Kontynuuj"
+
+msgid "BUTTON_EDIT_EMAIL_ADDRESS"
+msgstr "Zmień adres e-mail"
+
+msgid "SEARCH_FOR_SENDER_EMAIL_FORMAT"
+msgstr "Nie dostałeś maila? Sprawdź swoją skrzynkę na spam i szukaj %s. Jeżeli znajdziesz go w skrzynce na spam, najpierw zaznacz go jako Nie Spam."
+
+msgid "NEW_USER_INTRO_POST_INTRO_CHANNEL"
+msgstr "Kiedy jesteś gotowy, przedstaw się w naszym kanale 'Wprowadzenia', w kategorii 'Osobiste'."

--- a/pl_PL/LC_MESSAGES/mailSettings.po
+++ b/pl_PL/LC_MESSAGES/mailSettings.po
@@ -1,0 +1,101 @@
+msgid "HEADER_MAIL_SETTINGS"
+msgstr "Ustawienia e-maila"
+
+msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
+msgstr "Musisz się zalogować, by zmieniać ustawienia e-maila."
+
+msgid "MAIL_TYPE"
+msgstr "Typ"
+
+msgid "MAIL_STATUS"
+msgstr "Status"
+
+msgid "ENABLED"
+msgstr "Aktywny"
+
+msgid "DISABLED"
+msgstr "Nieaktywnu"
+
+msgid "ENABLE"
+msgstr "Aktywuj"
+
+msgid "DISABLE"
+msgstr "Dezaktywuj"
+
+msgid "TAP_TO_ENABLE"
+msgstr "Wciśnij by aktywować"
+
+msgid "TAP_TO_DISABLE"
+msgstr "Wciśnij by dezaktywować"
+
+msgid "TYPE_NEWS_NAME"
+msgstr "Sudomemo News"
+
+msgid "TYPE_NEWS_DESC"
+msgstr "Otrzymuj e-maile gdy coś nowego pojawia się w Sudomemo News"
+
+msgid "TYPE_PROMO_NAME"
+msgstr "Aktualności o serwisie"
+
+msgid "TYPE_PROMO_DESC"
+msgstr "Otrzymuj e-maile o nowych funkcjach, poradach i sztuczkach, a także nadchodzących wydarzeniach."
+
+msgid "TYPE_FAVE_NOTIF_NAME"
+msgstr "Dodano twój profil do ulubionych"
+
+msgid "TYPE_FAVE_NOTIF_DESC"
+msgstr "Otrzymuj e-maile gdy ktoś doda cię do Ulubionych"
+
+msgid "TYPE_COMMENT_NOTIF_NAME"
+msgstr "Otrzymano komentarz"
+
+msgid "TYPE_COMMENT_NOTIF_DESC"
+msgstr "Otrzymuj e-maile gdy ktoś komentuje na twoich Flipnote"
+
+msgid "TYPE_STAR_REPORT_NAME"
+msgstr "Codzienne podsumowanie gwiazdek"
+
+msgid "TYPE_STAR_REPORT_DESC"
+msgstr "Otrzymuj e-maile na koniec każdego dnia z ilością gwiazdek które otrzymałeś"
+
+msgid "TYPE_SPINOFF_NOTIF_NAME"
+msgstr "Ktoś tworzy Spin-off"
+
+msgid "TYPE_SPINOFF_NOTIF_DESC"
+msgstr "Otrzymuj e-maile gdy ktoś wysyła spin-off twojego Flipnota"
+
+msgid "TYPE_SECURITY_NOTIF_NAME"
+msgstr "Bezpieczeństwo konta"
+
+msgid "TYPE_SECURITY_NOTIF_DESC"
+msgstr "Otrzymuj e-maile gdy twój adres e-mail lub hasło jest aktualizowane"
+
+msgid "TYPE_REPORT_UPDATE_NAME"
+msgstr "Aktualizacje o zgłoszonej zawartości"
+
+msgid "TYPE_REPORT_UPDATE_DESC"
+msgstr "Otrzymuj e-maile gdy zmienimy status zawartości którą zgłosiłeś"
+
+msgid "TYPE_UNREAD_COMMENTS_NAME"
+msgstr "Nieprzeczytane komentarze"
+
+msgid "TYPE_UNREAD_COMMENTS_DESC"
+msgstr "Otrzymuj przez e-maila podsumowanie nowych komentarzy, które niedawno otrzymałeś"
+
+msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
+msgstr "Kliknij na status rodzaju maila by go zobaczyć lub zmienić."
+
+msgid "HEADER_CHANGE_EMAIL_SETTINGS"
+msgstr "Zmień ustawienia e-maila"
+
+msgid "DISABLE_CONFIRMATION_FORMAT"
+msgstr "Czy napewno chcesz deaktywować e-maile '%s'?"
+
+msgid "REENABLE_INSTRUCTIONS"
+msgstr "Jeżeli chcesz aktywować je ponownie, możesz to zrobić wchodząc w <strong>Ustawienia e-maila</strong> w twoim Pokoju Twórcy."
+
+msgid "EMAIL_SETTING_DISABLED_FINISH_FORMAT"
+msgstr "Zdeaktwowano '%s' e-maili."
+
+msgid "EMAIL_CHANGE_TOKEN_EXPIRED"
+msgstr "Link, którym podążasz, wygasł."

--- a/pl_PL/LC_MESSAGES/menuHeaders.po
+++ b/pl_PL/LC_MESSAGES/menuHeaders.po
@@ -1,0 +1,62 @@
+msgid "GET_STARTED"
+msgstr "Rozpocznij"
+
+msgid "WATCH_FLIPNOTES"
+msgstr "Wszystkie Flipnotes"
+
+msgid "CHANNELS"
+msgstr "Kanały"
+
+msgid "CATEGORIES"
+msgstr "Kategorie"
+
+msgid "FEATURED"
+msgstr "Wyróżnione"
+
+msgid "HOT_FLIPNOTES"
+msgstr "Gorące Flipnotes"
+
+msgid "ABOUT_SUDOMEMO"
+msgstr "O Sudomemo"
+
+msgid "CREATORS_ROOM"
+msgstr "Pokój Twórcy"
+
+msgid "NEWS"
+msgstr "Sudomemo News"
+
+msgid "CHATROOMS"
+msgstr "Pokoje czatu"
+
+msgid "SEARCH"
+msgstr "Szukaj"
+
+msgid "SEARCH_USER"
+msgstr "Szukaj użytkowników"
+
+msgid "SEARCH_FLIPNOTE"
+msgstr "Szukaj Flipnotes"
+
+msgid "RELOAD_USER"
+msgstr "Odśwież użytkownika"
+
+msgid "LOGIN"
+msgstr "Logowanie"
+
+msgid "LOGOUT"
+msgstr "Wylogowywanie"
+
+msgid "REGISTER"
+msgstr "Rejestracja"
+
+msgid "THEME_SHOP"
+msgstr "Sklep z motywami"
+
+msgid "MAIL"
+msgstr "Mail"
+
+msgid "TEST_TRANSLATION"
+msgstr "Tłumaczenie Angielskie"
+
+msgid "HELP"
+msgstr "Pomoc"

--- a/pl_PL/LC_MESSAGES/passwordResetEmail.po
+++ b/pl_PL/LC_MESSAGES/passwordResetEmail.po
@@ -1,0 +1,32 @@
+msgid "EMAIL_SUBJECT"
+msgstr "Reset hasła na Sudomemo"
+
+msgid "PASSWORD_HEADER"
+msgstr "Reset hasła na Sudomemo"
+
+msgid "TEXT_HELLO"
+msgstr "Witaj!"
+
+msgid "TEXT_EMAIL_PURPOSE"
+msgstr "Otrzymaliśmy zgłoszenie resetu hasła dla twojego konta."
+
+msgid "TEXT_RESET_LINK_FORMAT"
+msgstr "Kliknij <a target=\"_blank\" href=\"%s\">tutaj</a> aby kontynuować."
+
+msgid "TEXT_URL_PLAIN_DISPLAY"
+msgstr "Możesz również skopiować i wkleić poniższy link do nowego okna:"
+
+msgid "PASSWORD_RESET_SENT_FORMAT"
+msgstr "Zgłoszenie resetu hasła zostało wysłane na adres %s."
+
+msgid "NO_EMAIL_CONTACT_SUPPORT"
+msgstr "Nie masz dodanego adresu e-mail. Skontaktuj się z nami poprzez nasz serwer na Discordzie."
+
+msgid "HEADER_FORGOT_PASSWORD"
+msgstr "Zapomniałem hasła"
+
+msgid "SESSION_EXPIRED"
+msgstr "Twoja sesja wygasła. Spróbuj ponownie."
+
+msgid "RESET_EXPIRE_TIME"
+msgstr "Ten link będzie ważny przez dwanaście (12) godzin."

--- a/pl_PL/LC_MESSAGES/profilePicture.po
+++ b/pl_PL/LC_MESSAGES/profilePicture.po
@@ -1,0 +1,26 @@
+msgid "SET_PROFILE_PICTURE"
+msgstr "Ustaw zdjęcie profilowe"
+
+msgid "PROMPT_CHANGE_YOUR_PROFILE_IMAGE"
+msgstr "Zmienić zdjęcie profilowe?"
+
+msgid "CONTINUE_SET_AS_PROFILE_PICTURE"
+msgstr "Potwierdź"
+
+msgid "CURRENT"
+msgstr "Aktualne"
+
+msgid "NEW"
+msgstr "Nowe"
+
+msgid "PROFILE_PICTURE_SET"
+msgstr "Zdjęcie profilowe ustawione pomyślnie!"
+
+msgid "RETURN_TO_FLIPNOTE"
+msgstr "Wróć do Flipnote"
+
+msgid "CREATORS_ROOM"
+msgstr "Pokój Twórcy"
+
+msgid "CANCEL"
+msgstr "Anuluj"

--- a/pl_PL/LC_MESSAGES/profilePicture.po
+++ b/pl_PL/LC_MESSAGES/profilePicture.po
@@ -1,3 +1,6 @@
+msgid "LOGIN_REQUIRED_TO_CHANGE"
+msgstr "Musisz się zalogować by zmienić zdjęcie profilowe."
+
 msgid "SET_PROFILE_PICTURE"
 msgstr "Ustaw zdjęcie profilowe"
 

--- a/pl_PL/LC_MESSAGES/reportContent.po
+++ b/pl_PL/LC_MESSAGES/reportContent.po
@@ -60,3 +60,6 @@ msgstr "Ten komentarz został już wysłany na Sudomemo."
 
 msgid "CONFIRM_EMAIL_BEFORE_REPORTING"
 msgstr "Potwierdź swój adres e-mail zanim zgłosisz zawartość."
+
+msgid "THANKS_FOR_REPORTING"
+msgstr "Otrzymaliśmy twoje zgłoszenie. Dziękujemy za pomoc w zmienianiu Sudomemo na lepsze!"

--- a/pl_PL/LC_MESSAGES/reportContent.po
+++ b/pl_PL/LC_MESSAGES/reportContent.po
@@ -1,0 +1,62 @@
+msgid "HEADER_REPORT_CONTENT"
+msgstr "Zgłoś zawartość"
+
+msgid "CHAT_MESSAGE"
+msgstr "wiadomość na czacie"
+
+msgid "COMMENT"
+msgstr "komentarz"
+
+msgid "FLIPNOTE"
+msgstr "Flipnote"
+
+msgid "YOU_ARE_REPORTING_THIS_FORMAT"
+msgstr "Zgłaszasz %s:"
+
+msgid "USER_HAS_ALREADY_REPORTED_FORMAT"
+msgstr "Zgłosiłeś już ten/tą %s."
+
+msgid "HEADER_VIOLATION_CATEGORY"
+msgstr "Kategoria wykroczenia::"
+
+msgid "FLIPNOTE_TITLE_FORMAT"
+msgstr "Flipnote stworzony przez %s"
+
+msgid "CREATOR_FORMAT"
+msgstr "Twórca: %s"
+
+msgid "NOTICE_REPORT_OTHER_ISSUES"
+msgstr "Ten formularz jest jedynie do zgłaszania zawartości wysyłanej przez użytkownika. Żeby zgłosić jego zachowanie, lub dla innych problemów i zgłoszeń, skontaktuj się z naszym zespołem przez e-maila."
+
+msgid "REPORT_INSTRUCTIONS"
+msgstr "Krótko zapisz, dlaczego uważasz że ta zawartość narusza warunki korzystania z Sudomemo. Kiedy już wyślesz swój opis, kliknij Wróć by powrócić do Flipnote."
+
+msgid "NO_BLANK_REPORTS"
+msgstr "Nie możesz wysłać pustego zgłoszenia."
+
+msgid "LIMIT_ONE_REPORT"
+msgstr "Uwaga: Możesz zgłosić tę zawartość tylko jeden raz. Dodatkowe zgłoszenia nie będą rejestrowane, więc zapisz swoje uwagi w jednym komentarzu."
+
+msgid "REPORT_EXPLANATION_FAILED"
+msgstr "Podczas wysyłania zgłoszenia wystąpił błąd."
+
+msgid "RESTRICTED_CANCEL"
+msgstr "Nie możesz zgłaszać zawartości jeżeli twoje konto jest zawieszone i nie może interaktować się z Sudomemo w jakikolwiek sposób."
+
+msgid "HEADER_REASON"
+msgstr "Powód:"
+
+msgid "LOGIN_REQUIRED_TO_CONTINUE"
+msgstr "Zaloguj się, żeby kontynuować."
+
+msgid "LOGIN_REQUIRED_TO_REPORT_CONTENT"
+msgstr "Zaloguj się, żeby wysyłać zgłoszenia zawartości."
+
+msgid "REPORT_FAILED_USER_BANNED"
+msgstr "Zgłoszenie nie powiodło się: jesteś zbanowany z Sudomemo."
+
+msgid "DUPLICATE_COMMENT_FAILED"
+msgstr "Ten komentarz został już wysłany na Sudomemo."
+
+msgid "CONFIRM_EMAIL_BEFORE_REPORTING"
+msgstr "Potwierdź swój adres e-mail zanim zgłosisz zawartość."

--- a/pl_PL/LC_MESSAGES/search.po
+++ b/pl_PL/LC_MESSAGES/search.po
@@ -1,0 +1,44 @@
+msgid "HEADER_PREV"
+msgstr "Poprzednia"
+
+msgid "HEADER_NEXT"
+msgstr "Następna"
+
+msgid "PAGE_FORMAT"
+msgstr "Strona %d"
+
+msgid "SEARCH"
+msgstr "Szukaj"
+
+msgid "USERNAME"
+msgstr "Nazwa użytkownika"
+
+msgid "RESULTS"
+msgstr "Wyniki"
+
+msgid "SEARCH_USERNAME"
+msgstr "Szukaj użytkownika"
+
+msgid "PLEASE_ENTER_USERNAME"
+msgstr "Wpisz nazwę użytkownika..."
+
+msgid "RESULTS_FOUND_FORMAT_SINGULAR"
+msgstr "%1$d wynik znaleziony dla \"%2$s\""
+
+msgid "RESULTS_FOUND_FORMAT_MULTIPLE"
+msgstr "%1$d wyniki znalezione dla \"%2$s\""
+
+msgid "NO_RESULTS_FOUND"
+msgstr "Brak znalezionych wyników"
+
+msgid "SEARCH_SHORT_KEY"
+msgstr "ID Flipnote"
+
+msgid "SHORT_KEY_NO_RESULTS"
+msgstr "Nie znaleziono Flipnotes"
+
+msgid "SHORT_KEY_FORMAT_GUIDE"
+msgstr "Nie znajdujesz tego, czego szukasz? Możliwe, że źle wpisałeś ID Flipnote. ID Flipnote mają 6 znaków i można je znaleść w sekcji z informacjami o Flipnote."
+
+msgid "SHORT_KEY_SIMILAR_FOUND_CASE_SENSITIVE"
+msgstr "Nie znaleziono niczego, ale istnieje podoble ID. Pamiętaj że ID Flipnote uwzględniają wielkość liter i zazwyczaj składają się z całych dużych liter i cyfr."

--- a/pl_PL/LC_MESSAGES/sudomemoNewsBrowser.po
+++ b/pl_PL/LC_MESSAGES/sudomemoNewsBrowser.po
@@ -1,0 +1,11 @@
+msgid "PREV"
+msgstr "Poprzednia"
+
+msgid "NEXT"
+msgstr "Następna"
+
+msgid "PAGE_FORMAT"
+msgstr "Strona %d"
+
+msgid "HEADER_NEWS"
+msgstr "Wiadomości"

--- a/pl_PL/LC_MESSAGES/sudomemoPlus.po
+++ b/pl_PL/LC_MESSAGES/sudomemoPlus.po
@@ -1,0 +1,82 @@
+# Sudomemo Plus Legacy Citizenship Activation
+msgid "SUDOMEMO_PLUS_LEGACY_HEADER"
+msgstr "Witaj w Sudomemo Plus!"
+
+msgid "GREETING_LEGACY_ACTIVATE_FORMAT"
+msgstr "Witaj, %s!"
+
+msgid "LEGACY_ACTIVATE_CITIZENSHIP_CHANGE"
+msgstr "Sudomemo Citizenship zostało zastąpione przez Sudomemo Plus!"
+
+msgid "LEGACY_ACTIVATE_PLUS_TEASER"
+msgstr "Sudomemo Plus daje ci dostęp do wielu dodatkowych funkcji, takich jak wygładzanie i ulepszanie dźwięku twoich Flipnotes na Sudomemo Theatre, a także kolorowe komentarze i inne niezłe funkcje!"
+
+msgid "LEGACY_ACTIVATE_EARN_PLUS"
+msgstr "Sudomemo Plus może być uzyskane poprzez wykorzystanie losu wykupionego w naszym sklepie lub jeżeli twój Flipnote wygra w jednym z naszych Cotygodniowych Tematów."
+
+msgid "LEGACY_ACTIVATE_GRANDFATHERED_BONUS"
+msgstr "Ponieważ poprzednio miałeś Citizenship, daliśmi ci darmowy miesiąc Sudememo Plus. Porozglądaj się po naszej stronie i wypróbuj kilku nowych funkcji!
+
+msgid "CONTINUE"
+msgstr "Kontynuuj"
+
+# My Sudomemo Plus
+
+msgid "MANAGE_PLUS_HEADER"
+msgstr "Moje Sudomemo Plus"
+
+msgid "MANAGE_PLUS_REMAINING"
+msgstr "Pozostało ci %s dni Sudomemo Plus."
+
+msgid "MANAGE_PLUS_HOW_TO_EARN_PLUS"
+msgstr "Sudomemo Plus może być uzyskane poprzez wykorzystanie losu wykupionego w naszym sklepie lub jeżeli twój Flipnote wygra w jednym z naszych Cotygodniowych Tematów."
+
+msgid "AVAILABLE_PLUS_FEATURES"
+msgstr "Dzięki Sudomemo Plus masz dostęp do tych funkcji. Sprawdzaj tę sekcję raz na jakiś czas!"
+
+msgid "FOOTNOTE_PLATFORM_FEATURE_PARITY"
+msgstr "Niektóre funkcjie, takie jak wygładzanie i ulepszenie dźwięku Flipnotes, są widoczne jedynie w Sudomemo Theatre."
+
+msgid "FLIPNOTE_SMOOTHING"
+msgstr "Wygładzanie Flipnote"
+
+msgid "FLIPNOTE_AUDIO_ENHANCEMENT"
+msgstr "Ulepszenie dźwięku Flipnote"
+
+msgid "COLORFUL_COMMENTS"
+msgstr "Pisz kolorowe komentarze"
+
+msgid "DOWNLOAD_YOUR_COMMENTS"
+msgstr "Pobierz swoje komentarze jako Flipnote"
+
+msgid "THEME_PUBLISHER_ACCESS"
+msgstr "Wysyłaj własne motywy do sklepu z motywami"
+
+msgid "FLIPNOTE_ANALYTICS"
+msgstr "Otrzymaj dostęp do informacji analitycznych o twoich Flipnotes"
+
+msgid "SUDOMEMO_GAME_ACCESS"
+msgstr "Graj w specjalne gry z poziomu Sudomemo!"
+
+msgid "NO_THEATRE_ADS"
+msgstr "Brak reklam w Sudomemo Theatre"
+
+msgid "INCREASED_FOLLOW_LIMIT"
+msgstr "Podniesiony limit obserwowanych osób - do %s Twórców"
+
+# Sudomemo Plus Running Low Message
+
+msgid "PLUS_RUNNING_OUT_MSG_TITLE"
+msgstr "Moje Sudomemo Plus"
+
+msgid "PLUS_RUNNING_OUT_MSG_INTRO"
+msgstr "Witaj, %s!"
+
+msgid "PLUS_RUNNING_OUT_MSG_DAYS_REMAINING_FORMAT"
+msgstr "Przypominamy, że zostało ci %s dni Sudomemo Plus."
+
+msgid "PLUS_RUNNING_OUT_MSG_HOW_TO_EARN_PLUS"
+msgstr "Nie zapomnij, że Sudomemo Plus może być uzyskane poprzez wykorzystanie losu wykupionego w naszym sklepie lub jeżeli twój Flipnote wygra w jednym z naszych Cotygodniowych Tematów."
+
+msgid "PLUS_RUNNING_OUT_MSG_HAPPY_FLIPNOTING"
+msgstr "Wesołego Flipnotowania!"

--- a/pl_PL/LC_MESSAGES/sudomemoPlus.po
+++ b/pl_PL/LC_MESSAGES/sudomemoPlus.po
@@ -15,7 +15,7 @@ msgid "LEGACY_ACTIVATE_EARN_PLUS"
 msgstr "Sudomemo Plus może być uzyskane poprzez wykorzystanie losu wykupionego w naszym sklepie lub jeżeli twój Flipnote wygra w jednym z naszych Cotygodniowych Tematów."
 
 msgid "LEGACY_ACTIVATE_GRANDFATHERED_BONUS"
-msgstr "Ponieważ poprzednio miałeś Citizenship, daliśmi ci darmowy miesiąc Sudememo Plus. Porozglądaj się po naszej stronie i wypróbuj kilku nowych funkcji!
+msgstr "Ponieważ poprzednio miałeś Citizenship, daliśmi ci darmowy miesiąc Sudememo Plus. Porozglądaj się po naszej stronie i wypróbuj kilku nowych funkcji!"
 
 msgid "CONTINUE"
 msgstr "Kontynuuj"

--- a/pl_PL/LC_MESSAGES/themeShop.po
+++ b/pl_PL/LC_MESSAGES/themeShop.po
@@ -1,0 +1,101 @@
+msgid "THEME_SHOP_LOGIN_REQUIRED"
+msgstr "Musisz się zalogować by przeglądać sklep z motywami."
+
+msgid "THEME_SHOP_MAINPAGE_HEADER"
+msgstr "W sklepie z motywami możesz wykupić nowe motywy dla twojego Pokoju Twórcy!"
+
+msgid "THEME_SHOP_LEARN_MORE_HEADER"
+msgstr "Dowiedz się więcej o sklepie z motywami"
+
+msgid "THEME_SHOP_REPORT_ISSUES_HEADER"
+msgstr "Kliknij ten link żeby zgłosić motyw który nie działa poprawnie."
+
+msgid "THEME_SHOP_MAINPAGE_EXCHANGE_COST_FORMAT"
+msgstr "Kup za %d Zielonych Gwiazdek"
+
+msgid "THEME_SHOP_MAINPAGE_FREE_STARTER_THEMES"
+msgstr "Darmowe motywy na rozpoczęcie"
+
+msgid "CONGRATULATIONS"
+msgstr "Gratulacje!"
+
+msgid "SEE_MORE"
+msgstr "Zobacz więcej"
+
+msgid "PREVIEW"
+msgstr "Podgląd"
+
+msgid "BUY"
+msgstr "Kup"
+
+msgid "THEME"
+msgstr "Motyw"
+
+msgid "PRICE"
+msgstr "Cena"
+
+msgid "CREATOR"
+msgstr "Twórca"
+
+msgid "DESCRIPTION"
+msgstr "Opis"
+
+msgid "YOU_HAVE"
+msgstr "Twoje Kolorowe Gwiazdki:"
+
+msgid "USERNAME"
+msgstr "Nazwa użytkownika"
+
+msgid "CANCEL"
+msgstr "Anuluj"
+
+msgid "CONFIRM"
+msgstr "Potwierdź"
+
+msgid "CREATORS_ROOM"
+msgstr "Pokój Twórcy"
+
+msgid "SHOP_MENU"
+msgstr "Menu sklepu"
+
+msgid "NO_DESCRIPTION_AVAILABLE"
+msgstr "Brak opisu"
+
+msgid "THEME_SHOP_SELECT_PAYMENT"
+msgstr "Wybierz metodę płatności"
+
+msgid "THEME_SHOP_SELECTED_PAYMENT"
+msgstr "Wybrana metoda płatności"
+
+msgid "THEME_SHOP_STAR_BALANCE_TOO_LOW"
+msgstr "Przeprasamy, nie starczy ci Zielonych Gwiazdek na kupienie tego motywu."
+
+msgid "THEME_SHOP_CHOOSE_CAREFULLY_BEFORE_BUYING"
+msgstr "Wszystkie zakupy są pernamentne, wybierz uważnie zanim potwierdzisz kupno!"
+
+msgid "THEME_SHOP_YOU_OWN_THIS_THEME"
+msgstr "Już posiadasz ten motyw."
+
+msgid "THEME_SHOP_PUBLIC_THEME"
+msgstr "Wszyscy użytkownicy mają darmowy dostęp do tego motywu."
+
+msgid "THEME_SHOP_OWNED_THEME_TRANSACTION_FORMAT"
+msgstr "Kupiłeś ten motyw %s za %d Zielonych Gwiazdek."
+
+msgid "THEME_SHOP_CONFIRM_PURCHASE_BELOW"
+msgstr "Potwierdź swoją transakcję poniżej."
+
+msgid "THEME_SHOP_STARS_LEFT_AFTER_PAYMENT"
+msgstr "Kolorowe Gwiazdki pozostałe po płatności:"
+
+msgid "THEME_SHOP_POST_PURCHASE"
+msgstr "Twoja transakcja powiodła się! Wejdź do sekcji \"Moje motywy\" w twoim Pokoju Twórcy by ją wybrać!"
+
+msgid "NAVIGATION_PREVIOUS"
+msgstr "Poprzednia"
+
+msgid "NAVIGATION_NEXT"
+msgstr "Następna"
+
+msgid "THEME_SHOP_SAMPLE_PROFILE"
+msgstr "Przykładowy profil"

--- a/pl_PL/LC_MESSAGES/themeShop.po
+++ b/pl_PL/LC_MESSAGES/themeShop.po
@@ -1,3 +1,6 @@
+msgid "THEME_SHOP"
+msgstr "Sklep z motywami"
+
 msgid "THEME_SHOP_LOGIN_REQUIRED"
 msgstr "Musisz się zalogować by przeglądać sklep z motywami."
 

--- a/pl_PL/LC_MESSAGES/tickets.po
+++ b/pl_PL/LC_MESSAGES/tickets.po
@@ -1,0 +1,128 @@
+# Code Redemption
+
+msgid "REDEEM_CODE"
+msgstr "Wykorzystaj kod"
+
+msgid "ENTER_CODE_TO_REDEEM"
+msgstr "Wpisz kod który chcesz wykorzystać poniżej."
+
+msgid "CODE_ALREADY_USED"
+msgstr "Wpisany kod został już użyty."
+
+msgid "CODE_INVALID"
+msgstr "Wpisany kod jest niepoprawny."
+
+msgid "CODE_NONEXISTING_OR_EXPIRED"
+msgstr "Wpisany kod jest niepoprawny lub wygasł."
+
+msgid "LOGIN_REQUIRED_REDEEM_CODE"
+msgstr "Musisz się zalogować zanim wykorzystasz kod."
+
+# Ticket delivery
+
+msgid "YOU_GOT_A_TICKET"
+msgstr "Otrzymałeś los!"
+
+msgid "CONTINUE"
+msgstr "Kontynuuj"
+
+# Inventory
+
+msgid "INVENTORY"
+msgstr "Ekwipunek"
+
+msgid "USE_ITEM"
+msgstr "Użyj"
+
+msgid "INVENTORY_IS_EMPTY"
+msgstr "Twój ekwipunek jest pusty."
+
+# Ticket redemption
+
+msgid "TICKET_REDEEM_WIN_FORMAT"
+msgstr "Wykorzystałeś %s!"
+
+msgid "TICKET_REDEEM_LOSE_FORMAT"
+msgstr "Wykorzystałeś %s, ale..."
+
+msgid "TICKET_REDEEM_NO_PRIZES"
+msgstr "Nic nie wygrałeś. Przepraszamy!"
+
+msgid "COLOR_STARS"
+msgstr "Kolorowe Gwiazdki"
+
+msgid "CREATORS_ROOM_THEME"
+msgstr "Motyw do Pokoju Twórcy"
+
+msgid "SUDOMEMO_CITIZENSHIP"
+msgstr "Sudomemo Citizenship"
+
+msgid "THEME_AVAILABLE_FOR_USE"
+msgstr "Możesz teraz używać tego motywu w twoim Pokoju Twórcy!"
+
+msgid "SUDOMEMO_PLUS"
+msgstr "Sudomemo Plus"
+
+msgid "SUDOMEMO_PLUS_FORMAT"
+msgstr "Otrzymałeś %s dni Sudomemo Plus!"
+
+msgid "SUDOMEMO_PLUS_BALANCE_FORMAT"
+msgstr "Balans: %s dni"
+
+# Each ticket type will have a name and a description 
+
+msgid "TICKET_NAME_demo_ticket"
+msgstr "Los demonstracyjny"
+
+msgid "TICKET_DESC_demo_ticket"
+msgstr "Oczywyście, to jest opis dla losu demonstracyjnego."
+
+msgid "TICKET_NAME_regular_ticket"
+msgstr "Zwyczajny los"
+
+msgid "TICKET_DESC_regular_ticket"
+msgstr "Dziękujemy za używanie Sudomemo!"
+
+msgid "TICKET_NAME_twitter_promo_ticket"
+msgstr "Los z promocji na Twitterze"
+
+msgid "TICKET_DESC_twitter_promo_ticket"
+msgstr "Dziękujemy za obserwowanie Sudomemo na Twitterze!"
+
+msgid "TICKET_NAME_instagram_promo_ticket"
+msgstr "Los z promocji na Instagramie"
+
+msgid "TICKET_DESC_instagram_promo_ticket"
+msgstr "Dziękujemy za obserwowanie Sudomemo na Instagramie!"
+
+msgid "TICKET_NAME_weekly_topic_winner_ticket"
+msgstr "Los za wygraną w Cotygodniowym Temacie"
+
+msgid "TICKET_DESC_weekly_topic_winner_ticket"
+msgstr "Gratulujemy wygranej w Cotygodniowym Temacie Sudomemo!"
+
+msgid "TICKET_NAME_birthday_ticket"
+msgstr "Urodzinowy los"
+
+msgid "TICKET_DESC_birthday_ticket"
+msgstr "Sto lat!"
+
+msgid "TICKET_NAME_love_anniversary_ticket"
+msgstr "Rocznicowy los"
+
+# The last character of this message is the DSi symbol for a heart. Don't remove it.
+msgid "TICKET_DESC_love_anniversary_ticket" 
+msgstr "Wesołej rocznicy "
+
+# Sudomemo Plus
+msgid "TICKET_NAME_one_month_plus_ticket"
+msgstr "Los na Sudomemo Plus (Jeden miesiąc)"
+
+msgid "TICKET_DESC_one_month_plus_ticket"
+msgstr "Ten los da ci jeden miesiąc Sudomemo Plus!"
+
+msgid "TICKET_NAME_one_year_plus_ticket"
+msgstr "Los na Sudomemo Plus (Jeden rok)"
+
+msgid "TICKET_DESC_one_year_plus_ticket"
+msgstr "Ten los da ci jeden rok Sudomemo Plus!"

--- a/pl_PL/LC_MESSAGES/tickets.po
+++ b/pl_PL/LC_MESSAGES/tickets.po
@@ -126,3 +126,6 @@ msgstr "Los na Sudomemo Plus (Jeden rok)"
 
 msgid "TICKET_DESC_one_year_plus_ticket"
 msgstr "Ten los da ci jeden rok Sudomemo Plus!"
+
+msgid "DONT_HAVE_ANY_TO_USE"
+msgstr "Nie masz tego przedmiotu, więc nie możesz go użyć."

--- a/pl_PL/LC_MESSAGES/unfulfilledSignupEmail.po
+++ b/pl_PL/LC_MESSAGES/unfulfilledSignupEmail.po
@@ -1,0 +1,17 @@
+msgid "EMAIL_SUBJECT"
+msgstr "Potwierdzenie rejestracji na Sudomemo"
+
+msgid "SIGNUP_HEADER"
+msgstr "Potwierdzenie rejestracji na Sudomemo"
+
+msgid "TEXT_HELLO"
+msgstr "Witaj!"
+
+msgid "TEXT_EMAIL_PURPOSE"
+msgstr "Potwierdź swoją rejestrację na Sudomemo."
+
+msgid "TEXT_VERIFICATION_LINK_FORMAT"
+msgstr "Kliknij <a target=\"_blank\" href=\"%s\">tutaj</a> aby kontynuować!"
+
+msgid "TEXT_URL_PLAIN_DISPLAY"
+msgstr "Możesz również skopiować i wkleić poniższy link do nowego okna:"

--- a/pl_PL/LC_MESSAGES/unreadComments.po
+++ b/pl_PL/LC_MESSAGES/unreadComments.po
@@ -1,0 +1,17 @@
+msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
+msgstr "Musisz się zalogować by wyświetlić tą stronę."
+
+msgid "HEADER_UNREAD_COMMENTS"
+msgstr "Nieprzeczytane komentarze"
+
+msgid "NO_UNREAD_COMMENTS"
+msgstr "Nie masz nieprzeczytanych komentarzy."
+
+msgid "TAP_ON_FLIPNOTE_ID_TO_VISIT_COMMENTS"
+msgstr "Klikij na ID Flipnote żeby wyświetlić wszystkie komentarze."
+
+msgid "FLIPNOTE_ID"
+msgstr "ID Flipnote"
+
+msgid "UNREAD"
+msgstr "Nieprzeczytane"

--- a/pl_PL/LC_MESSAGES/unreadCommentsEmail.po
+++ b/pl_PL/LC_MESSAGES/unreadCommentsEmail.po
@@ -1,0 +1,20 @@
+msgid "EMAIL_SUBJECT_FORMAT"
+msgstr "[Sudomemo] %s, dostałeś nowe komentarze na twoich Flipnotes!"
+
+msgid "TITLE_NEW_COMMENTS"
+msgstr "Nowe komentarze"
+
+msgid "HELLO_FORMAT"
+msgstr "Witaj, %s!"
+
+msgid "TEXT_YOU_HAVE_X_COMMENTS_FROM_FORMAT"
+msgstr "Otrzymałeś %d nowe komentarze na Sudomemo od %s"
+
+msgid "AND"
+msgstr "i"
+
+msgid "AND_X_OTHERS_FORMAT"
+msgstr "i %s innych."
+
+msgid "TEXT_HOW_TO_VIEW_UNREAD_COMMENTS_TAP_ICON_FORMAT"
+msgstr "Możesz je przeczytać wciskając %s na twoim pasku powiadomień."

--- a/pl_PL/LC_MESSAGES/userMovieList.po
+++ b/pl_PL/LC_MESSAGES/userMovieList.po
@@ -1,0 +1,23 @@
+msgid "UPPERTITLE"
+msgstr "Przeglądaj"
+
+msgid "NEXT"
+msgstr "Następna strona"
+
+msgid "PREV"
+msgstr "Poprzednia strona"
+
+msgid "PAGE"
+msgstr "Strona"
+
+msgid "PAGE_COUNTER_FORMAT"
+msgstr "%d z %d"
+
+msgid "FLIPNOTES_BY_FORMAT"
+msgstr "Flipnotes stworzone przez %s"
+
+msgid "STARRED_BY_FORMAT"
+msgstr "Zagwiazdkowane przez %s"
+
+msgid "FAVORITES_FEED_FORMAT"
+msgstr "Strumień Ulubionych dla %s"


### PR DESCRIPTION
Current status: The base translation is done, although it's a little rough around the edges. It can be merged without changes, but it would be nice if somebody could double-check it beforehand.

## Caveats

- In a lot of cases, the user is referred to by male gendered words (``wysłał``, ``wysłałeś``). This could be mitigated in two ways:
  * changing the words to "add" the female endings (for example ``wysłał(a)`` or ``wysłałeś/aś``)
  * changing the words to use ``strona bierna`` (for example ``wysłano``)
- ``Flipnotes`` is not translated, and instead used directly (for example ``Pokaż Flipnotes``). In my opinion, ``Flipnotey``, ``Flipnote-y`` or ``Flipnoty`` as alternatives feel a bit off.