### PR TITLE
Update German translation (#185)

### DIFF
--- a/de_DE/LC_MESSAGES/blockSettings.po
+++ b/de_DE/LC_MESSAGES/blockSettings.po
@@ -1,5 +1,5 @@
 msgid "LOGIN_REQUIRED_TO_MANAGE_BLOCKS"
-msgstr "Du musst eingeloggt sein um die blockierten Benutzer zu bearbeiten."
+msgstr "Du musst angemeldet sein, um blockierte Benutzer zu bearbeiten."
 
 msgid "NO_USERS_BLOCKED"
 msgstr "Du hast keine Benutzer blockiert."
@@ -8,52 +8,52 @@ msgid "BLOCKED_USERS"
 msgstr "Blockierte Benutzer"
 
 msgid "BLOCK_USER"
-msgstr "Benutzer Blockieren"
+msgstr "Benutzer blockieren"
 
 msgid "COMMENT_BLOCK_IS_MUTUAL"
-msgstr "Wenn du einmal einen Benutzer blockiert hast, werdet ihr nicht mehr in der lage sein eure flipnotes zu kommentieren."
+msgstr "Wenn du einmal einen Benutzer blockiert hast, könnt ihr auf den Flipnotes des jeweils Anderen keine Kommentare senden."
 
 msgid "USER_HAS_BEEN_BLOCKED"
 msgstr "Dieser Benutzer wurde blockiert."
 
 msgid "IF_YOU_WISH_TO_UNBLOCK"
-msgstr "Wenn du jemals wieder einen Benutzer entblockieren möchtest, kannst du ihn in deimen Creators Room unter dein Blockierte-Benutzer-Menü entblockieren."
+msgstr "Wenn du einen Benutzer jedoch wieder entblocken möchtest, kannst du ihn in deinem Ersteller-Raum unter dein Blockierte-Benutzer-Menü entblocken."
 
 msgid "CONFIRM_BLOCK"
 msgstr "Blockieren bestätigen"
 
 msgid "USER_ALREADY_BLOCKED"
-msgstr "Du hast diesen Benutzer schon blockiert. Du kannst ihn in deimen Creators Room unter den Blockierte-Benutzer-Menü entblockieren, aber du musst 24 Stunden warten bis du sie wieder blockieren kannst."
+msgstr "Du hast diesen Benutzer schon blockiert. Du kannst ihn in deinem Ersteller-Raum unter Blockierte Benutzer entblocken. Du musst aber 24 Stunden warten, bis du ihn wieder blockieren kannst."
 
 msgid "ONE_DAY_WAIT_BEFORE_REBLOCK_FORMAT"
-msgstr "Du hast zuvor den Benutzer entblockiert. Du kannst ihn nicht nochmal bis %s blockieren"
+msgstr "Du hast diesen Benutzer kürzlich entblockt. Du kannst ihn nicht nochmal bis vor %s blockieren."
 
 msgid "UNBLOCK"
-msgstr "Entblockieren"
+msgstr "Entblocken"
 
 msgid "LOGIN_REQUIRED"
-msgstr "Du musst eingeloggt sein um diese Aktion auszuführen."
+msgstr "Du musst angemeldet sein, um diese Aktion auszuführen."
 
 msgid "TAP_BACK_TO_RETURN"
-msgstr "Tippe auf zurück um zu deinem Creators Room zurückzukehren"
+msgstr "Tippe auf Zurück, um zu deinem Ersteller-Raum zurückzukehren."
 
 msgid "UNBLOCK_USER"
-msgstr "Benutzer entblockieren"
+msgstr "Benutzer entblocken"
 
 msgid "CANNOT_UNBLOCK_NONBLOCKED_USER"
-msgstr "Du kannst den Benutzer nicht entblockieren da du ihn nicht blockiert hast."
+msgstr "Du kannst diesen Benutzer nicht entblocken, da du ihn momentan nicht blockierst."
 
 msgid "USER_HAS_BEEN_UNBLOCKED"
-msgstr "Dieser Benutzer wurde entblockiert."
+msgstr "Dieser Benutzer wurde entblockt."
 
 msgid "COMMENTING_ENABLED_AFTER_UNBLOCK"
-msgstr "Nachdem du diesen Benutzer entblockiert hast ksann er wieder deine Flipnotes kommentieren bis er dich blockiert hat."
+msgstr "Nachdem dieser Beutzer entblockt wurde, kann er wieder auf deinen Flipnotes kommentieren, wenn er dich nicht ebenfalls blockiert hat."
 
 msgid "UNBLOCK_WARNING_ONE_DAY_THRESHOLD"
-msgstr "Wenn du den Benutzer entblockierst dann musst du 24 Stunden warten um ihn wieder zu blockieren."
+msgstr "Hast du einen Benutzer entblockt, musst du 24 Stunden warten, bis du ihn wieder blockieren kannst."
 
 msgid "CONFIRM_UNBLOCK"
-msgstr "Entblockieren bestätigen"
+msgstr "Entblocken bestätigen"
 
 msgid "RECENTLY_UNBLOCKED_ONE_DAY_THRESHOLD"
-msgstr "Du hast diesen Benutzer schon entblockiert. Du musst 24 Stunden warten bis du ihn wieder blockieren kannst."
+msgstr "Du hast diesen Benutzer schon entblockt. Du musst 24 Stunden warten, bis du ihn wieder blockieren kannst."

--- a/de_DE/LC_MESSAGES/browseChannel.po
+++ b/de_DE/LC_MESSAGES/browseChannel.po
@@ -17,17 +17,16 @@ msgid "PAGE_COUNTER_FORMAT"
 msgstr "%d von %d"
 
 msgid "SPINOFFS"
-msgstr "Spinoffs"
+msgstr "Spin-Offs"
 
 msgid "BROWSE_BY_SONG"
-msgstr "Browse by Song"
+msgstr "Nach Song durchsuchen"
 
 msgid "BROWSE_BY_ARTIST"
-msgstr "Browse by Artist"
+msgstr "Nach Künstler durchsuchen"
 
 msgid "BROWSE_BY_ALBUM"
-msgstr "Browse by Album"
+msgstr "Nach Album durchsuchen"
 
 msgid "BROWSE_PLAYLIST"
-msgstr "Browse Playlist"
-
+msgstr "Playlist durchsuchen"

--- a/de_DE/LC_MESSAGES/browseFlipnotes.po
+++ b/de_DE/LC_MESSAGES/browseFlipnotes.po
@@ -14,7 +14,7 @@ msgid "HEADER_MOST_POPULAR"
 msgstr "Beliebteste"
 
 msgid "HEADER_NO_SPINOFFS"
-msgstr "Keine Spinoffs"
+msgstr "Keine Spin-Offs"
 
 msgid "HEADER_ROLEPLAYS"
 msgstr "Rollenspiele"
@@ -23,10 +23,10 @@ msgid "HEADER_BROWSE_FLIPNOTES"
 msgstr "Flipnotes durchsuchen"
 
 msgid "HEADER_FEATURED_FLIPNOTES"
-msgstr "Featured Flipnotes"
+msgstr "Vorgeschlagene Flipnotes"
 
 msgid "HEADER_RANDOM_FLIPNOTES"
-msgstr "Random Flipnotes"
+msgstr "Zufällige Flipnotes"
 
 msgid "HEADER_PAGE"
 msgstr "Seite"
@@ -44,7 +44,7 @@ msgid "PREV"
 msgstr "Zurück"
 
 msgid "POST_FLIPNOTE"
-msgstr "Post Flipnote"
+msgstr "Flipnote posten"
 
 msgid "CATEGORY_recent"
 msgstr "@Neueste Flipnotes"
@@ -56,10 +56,10 @@ msgid "CATEGORY_popular"
 msgstr "@Beliebteste"
 
 msgid "CATEGORY_featured"
-msgstr "@Featured Flipnotes"
+msgstr "@Vorgeschlagene Flipnotes"
 
 msgid "CATEGORY_random"
-msgstr "@Random Flipnotes"
+msgstr "@Zufällige Flipnotes"
 
 msgid "CATEGORY_feed"
 msgstr "@Feed"

--- a/de_DE/LC_MESSAGES/channelCategories.po
+++ b/de_DE/LC_MESSAGES/channelCategories.po
@@ -8,7 +8,7 @@ msgid "GENRES"
 msgstr "Genres"
 
 msgid "TOPICS"
-msgstr "Topics"
+msgstr "Themen"
 
 msgid "ROLEPLAYS"
 msgstr "Rollenspiele"
@@ -20,7 +20,7 @@ msgid "RESOURCES"
 msgstr "Ressourcen"
 
 msgid "PERSONAL"
-msgstr "Personal"
+msgstr "Persönliches"
 
 msgid "WEEKLY_TOPICS"
-msgstr "Wöchentliche Topics"
+msgstr "Wochen-Themen"

--- a/de_DE/LC_MESSAGES/channelDetails.po
+++ b/de_DE/LC_MESSAGES/channelDetails.po
@@ -1,35 +1,35 @@
 msgid "CHANNEL_NAME"
-msgstr "Channel Name"
+msgstr "Kanalname"
 
 msgid "CHANNEL_INFORMATION"
-msgstr "Channel Information"
+msgstr "Kanalinfo"
 
 msgid "FLIPNOTES"
 msgstr "Flipnotes"
 
 msgid "CHANNEL_ID"
-msgstr "Channel ID"
+msgstr "Kanal-ID"
 
 msgid "LOGIN_REQUIRED_TO_POST"
-msgstr "Du musst eingeloggt sein um ein Flipnote zu posten."
+msgstr "Du musst angemeldet sein, um ein Flipnote zu posten."
 
 msgid "CHANNEL_NOT_SPECIFIED"
-msgstr "Du musst ein Channel auswählen."
+msgstr "Du musst einen Kanal auswählen."
 
 msgid "FLIPNOTE_POST_FAIL_USER_BANNED"
 msgstr "Du wurdest von Sudomemo gebannt."
 
 msgid "FLIPNOTE_POST_FAILED"
-msgstr "Hochladen deines Flipnotes fehlgeschlagen! Versuche es später erneut."
+msgstr "Posten deines Flipnotes fehlgeschlagen! Versuche es später erneut."
 
 msgid "DUPLICATE_FLIPNOTE_FAILED"
-msgstr "Dieser Flipnote existiert schon in Sudomemo! Versuche ihn nochmal zu bearbeiten."
+msgstr "Dieses Flipnote existiert schon auf Sudomemo! Bearbeite es, und versuche es später erneut."
 
 msgid "FLIPNOTE_DATA_CORRUPTED"
-msgstr "Die Flipnote Datei ist beschädigt! Versuche es später erneut."
+msgstr "Die Flipnote-Datei ist beschädigt! Versuche es später erneut."
 
 msgid "NO_BLANK_FLIPNOTES_ALLOWED"
 msgstr "Du kannst keine leeren Flipnotes posten."
 
 msgid "NO_POSTS_WHILE_MUTED"
-msgstr "You may not post while you are muted."
+msgstr "Du kannst nichts hochladen, solange du stummgeschalten bist."

--- a/de_DE/LC_MESSAGES/channelList.po
+++ b/de_DE/LC_MESSAGES/channelList.po
@@ -1,14 +1,14 @@
 msgid "UPPERTITLE"
-msgstr "Channel"
+msgstr "Kanal"
 
 msgid "UPPERSUBBOTTOM"
-msgstr "Bitte wähle einen Channel aus!"
+msgstr "Bitte wähle einen Kanal aus!"
 
 msgid "NEXT"
-msgstr "Nächste Seite"
+msgstr "Weiter"
 
 msgid "PREV"
-msgstr "Vorherige Seite"
+msgstr "Zurück"
 
 msgid "FAVORITES"
 msgstr "Favoriten"

--- a/de_DE/LC_MESSAGES/chatrooms.po
+++ b/de_DE/LC_MESSAGES/chatrooms.po
@@ -1,5 +1,5 @@
 msgid "NO_COMMENTS_YET"
-msgstr "Es wurden hier keine Nachrichten versendet."
+msgstr "Hier wurden noch keine Nachrichten versendet."
 
 msgid "HEADER_COMMENTS"
 msgstr "Kommentare"
@@ -17,7 +17,7 @@ msgid "HEADER_REFRESH"
 msgstr "Neu laden"
 
 msgid "LOGIN_REQUIRED_TO_POST_CHAT_MESSAGE"
-msgstr "Du musst eingeloggt sein um eine Chat-Nachricht zu versenden."
+msgstr "Du musst angemeldet sein, um eine Chat-Nachricht zu versenden."
 
 msgid "CHAT_REPLY_FAILED"
 msgstr "Chat-Antwort fehlgeschlagen! Versuche es später erneut."
@@ -26,13 +26,13 @@ msgid "NO_BLANK_MESSAGES_ALLOWED"
 msgstr "Du kannst keine leere Nachricht versenden."
 
 msgid "FLIPNOTE_DATA_CORRUPTED"
-msgstr "Die Flipnote Datei ist beschädigt! Versuche es später erneut."
+msgstr "Die Flipnote-Datei ist beschädigt! Versuche es später erneut."
 
 msgid "NO_CHAT_MESSAGES_WHILE_MUTED"
-msgstr "Du wurdest stummgeschalten! Du kannst keine Chat-Nachrichten versenden wenn du stummgeschalten wurdest."
+msgstr "Du wurdest stummgeschalten! Du kannst keine Chat-Nachrichten versenden, wenn du stummgeschalten wurdest."
 
 msgid "DUPLICATE_COMMENT_FAILED"
-msgstr "Dieser Kommentar wurde schon in Sudomemo versendet."
+msgstr "Dieser Kommentar wurde schon auf Sudomemo versendet."
 
 msgid "COMMENT_FAILED_USER_BANNED"
 msgstr "Du wurdest von Sudomemo gebannt."

--- a/de_DE/LC_MESSAGES/colorPicker.po
+++ b/de_DE/LC_MESSAGES/colorPicker.po
@@ -1,17 +1,17 @@
 msgid "SET_PEN_COLOR"
-msgstr "Set Pen Color"
+msgstr "Stiftfarbe einstellen"
 
 msgid "SET_PAPER_COLOR"
-msgstr "Set Paper Color"
+msgstr "Hintergrundfarbe einstellen"
 
 msgid "SELECT_A_COLOR"
-msgstr "Select a color."
+msgstr "Wähle eine Farbe."
 
 msgid "CURRENT_COLOR"
-msgstr "Current color:"
+msgstr "Aktuelle Farbe:"
 
 msgid "CURRENT_COLOR_DEFAULT"
-msgstr "Current color: default"
+msgstr "Aktuelle Farbe: Standard"
 
 msgid "RETURN"
-msgstr "Return"
+msgstr "Zurück"

--- a/de_DE/LC_MESSAGES/commentDetails.po
+++ b/de_DE/LC_MESSAGES/commentDetails.po
@@ -2,10 +2,10 @@ msgid "COMMENT_DETAILS"
 msgstr "Kommentar-Details"
 
 msgid "MESSAGE_DETAILS"
-msgstr "Nachricht-Details"
+msgstr "Nachrichten-Details"
 
 msgid "AUTHOR"
-msgstr "Author"
+msgstr "Autor"
 
 msgid "COMMENT_BY_FORMAT"
 msgstr "Kommentar von %s"
@@ -20,13 +20,13 @@ msgid "FLIPNOTE_BY_FORMAT"
 msgstr "Flipnote von %s"
 
 msgid "COMMENT_ID"
-msgstr "Kommentar ID"
+msgstr "Kommentar-ID"
 
 msgid "MESSAGE_ID"
-msgstr "Nachricht ID"
+msgstr "Nachrichten-ID"
 
 msgid "CHAT_COMMENT_ID"
-msgstr "Chat-Kommentar ID"
+msgstr "Chat-Kommentar-ID"
 
 msgid "TIMESTAMP"
 msgstr "Zeitstempel"
@@ -35,7 +35,7 @@ msgid "POSTED_TO"
 msgstr "Hochgeladen zu"
 
 msgid "PRIVATE_CONVERSATION"
-msgstr "Private Konversation"
+msgstr "Privatunterhaltung"
 
 msgid "REPORT_CONTENT"
 msgstr "Melden"

--- a/de_DE/LC_MESSAGES/commonEmailStrings.po
+++ b/de_DE/LC_MESSAGES/commonEmailStrings.po
@@ -1,9 +1,8 @@
 msgid "TEXT_CHANGE_SETTINGS_PROMPT"
-msgstr "Want to adjust the emails you get from Sudomemo?"
+msgstr "Willst du verwalten, welche Emails du von Sudomemo erhalten möchtest?"
 
 msgid "TEXT_HOW_TO_CHANGE_SETTINGS_DSI"
-msgstr "You can easily update them by visiting your Creator's Room on Sudomemo and selecting <strong>Mail Settings</strong>."
+msgstr "Du kannst deine Präferenzen einfach in deinem Ersteller-Raum unter <strong>Mail-Einstellungen</strong> ändern."
 
 msgid "TEXT_WEB_SETTINGS_CHANGE_FORMAT"
-msgstr "Or, you can turn off these kinds of emails by clicking <a target=\"_blank\" href=\"%s\"><strong>here</strong></a>."
-
+msgstr "Wenn du jedoch keine Emails dieser Art erhalten möchtest, klicke <a target=\"_blank\" href=\"%s\"><strong>hier</strong></a>."

--- a/de_DE/LC_MESSAGES/creatorsRoom.po
+++ b/de_DE/LC_MESSAGES/creatorsRoom.po
@@ -2,16 +2,16 @@ msgid "SEE_MORE"
 msgstr "Mehr sehen..."
 
 msgid "STARRED_FLIPNOTES"
-msgstr "Markierte Flipnotes"
+msgstr "Bewertete Flipnotes"
 
 msgid "FAVORITE_USERS"
-msgstr "Lieblings Benutzer"
+msgstr "Favorisierte Benutzer"
 
 msgid "FAVORITES_FEED"
-msgstr "Lieblings Feed"
+msgstr "Favoriten-Feed"
 
 msgid "FAVORITE_CHANNELS"
-msgstr "Lieblings Channel"
+msgstr "Favorisierte Kanäle"
 
 msgid "USER_DOWNLOADCOUNT"
 msgstr "Downloads"
@@ -20,16 +20,16 @@ msgid "USER_VIEWCOUNT"
 msgstr "Aufrufe"
 
 msgid "USER_THEME"
-msgstr "Theme"
+msgstr "Kulisse"
 
 msgid "THEME_SHOP"
-msgstr "Theme Shop"
+msgstr "Kulissen-Shop"
 
 msgid "POSTED_COMMENTS"
-msgstr "Hochgeladene Kommentare"
+msgstr "Versendete Kommentare"
 
 msgid "POSTED_CHATCOMMENTS"
-msgstr "Chatraum-Nachrichten"
+msgstr "Versendete Chatraum-Nachrichten"
 
 msgid "FEATURE_USABILITY"
 msgstr "Benutzerfreundlichkeit"
@@ -41,10 +41,10 @@ msgid "NOT_USABLE"
 msgstr "Nicht benutzbar"
 
 msgid "SUDOMEMO_THEATRE_URL"
-msgstr "Sudomemo Theatre Link"
+msgstr "Sudomemo-Theatre-Link"
 
 msgid "FLIPNOTE_STUDIO_ID"
-msgstr "Flipnote Studio ID"
+msgstr "Flipnote-Studio-ID"
 
 msgid "SETTINGS"
 msgstr "Einstellungen"
@@ -62,16 +62,16 @@ msgid "ADMIN_ACCT_MUTED"
 msgstr "Stummgeschalten"
 
 msgid "ADMIN_USER_DETAILS"
-msgstr "Benutzer Details"
+msgstr "Benutzer-Details"
 
 msgid "ADMIN_LAST_SEEN"
 msgstr "Zuletzt gesehen"
 
 msgid "ADMIN_USER_STATUS"
-msgstr "Benutzer Status"
+msgstr "Benutzer-Status"
 
 msgid "ADMIN_ADMINISTRATIVE_ACTIONS"
-msgstr "Admin Aktionen"
+msgstr "Admin-Aktionen"
 
 msgid "BLOCK_COMMENTS_HEADER"
 msgstr "Nachrichten blockieren"
@@ -89,7 +89,7 @@ msgid "HEADER_FOLLOWERS"
 msgstr "Follower"
 
 msgid "HEADER_FOLLOWING"
-msgstr "Verfolgt"
+msgstr "Folgend"
 
 msgid "PREVIOUS"
 msgstr "Zurück"
@@ -98,19 +98,19 @@ msgid "NEXT"
 msgstr "Weiter"
 
 msgid "CHANGE_ROOM_THEME_LINK"
-msgstr "[Theme umändern]"
+msgstr "[Kulisse umändern]"
 
 msgid "SELECT_THEME"
-msgstr "Theme auswählen"
+msgstr "Kulisse auswählen"
 
 msgid "FANS"
 msgstr "Fans"
 
 msgid "EXAMPLE"
-msgstr "beispiel"
+msgstr "Beispiel"
 
 msgid "THEMETEST_SET_THEME"
-msgstr "Theme benutzen"
+msgstr "Kulisse benutzen"
 
 msgid "THEMETEST_NOTICE"
 msgstr "Bemerkung"
@@ -125,22 +125,22 @@ msgid "THEMETEST_NOTICE_2"
 msgstr "Bemerkung #2"
 
 msgid "THEMETEST_ACTIVE_TAB"
-msgstr "Aktiver tab"
+msgstr "Aktiver Tab"
 
 msgid "THEMETEST_INACTIVE_TAB"
-msgstr "Inaktiver tab"
+msgstr "Inaktiver Tab"
 
 msgid "PREVIEW"
-msgstr "Preview"
+msgstr "Vorschau"
 
 msgid "CREATORS_ROOM"
-msgstr "Creator's Room"
+msgstr "Ersteller-Raum"
 
 msgid "THEME_ERROR_THEME_NOT_OWNED"
-msgstr "Sorry! Du besitzt diesen Theme nicht."
+msgstr "Tut uns Leid! Du besitzt diese Kulisse nicht."
 
 msgid "THEME_SUCCESSFULLY_SET"
-msgstr "Theme erfolgreich ausgewählt!"
+msgstr "Kulisse erfolgreich ausgewählt!"
 
 msgid "BLOCKED_USERS"
 msgstr "Blockierte Benutzer"
@@ -152,28 +152,28 @@ msgid "FAN_COUNT_FORMAT"
 msgstr "Fans: %s"
 
 msgid "HEADER_MAIL_SETTINGS"
-msgstr "Mail Settings"
+msgstr "Mail-Einstellungen"
 
 msgid "HEADER_EDIT_BIOGRAPHY"
-msgstr "Edit Biography"
+msgstr "Biografie bearbeiten"
 
 msgid "SET_BIO_INSTRUCTIONS"
-msgstr "Enter your profile biography below. This will be displayed on Sudomemo and Sudomemo Theatre."
+msgstr "Gib deine Biografie hier unten ein. Sie wird auf Sudomemo und Sudomemo Theatre sichtbar sein."
 
 msgid "ENTER_BIO"
-msgstr "Enter Bio..."
+msgstr "Biografie eingeben..."
 
 msgid "101_CHARACTER_LIMIT_BIO"
-msgstr "Your biography is limited to 101 characters."
+msgstr "Die Länge der Biografie ist auf 101 Charaktere begrenzt."
 
 msgid "LEAVE_BLANK_TO_RESET_BIO"
-msgstr "To clear your biography, leave the form blank when submitting."
+msgstr "Die Biografie kann beim Speichern ohne Text zurückgesetzt werden."
 
 msgid "CURRENT_BIO"
-msgstr "Current Bio:"
+msgstr "Aktuelle Biografie:"
 
 msgid "FOLLOW_LIMIT_EXCEEDED_FORMAT"
-msgstr "You can't follow more than %d users."
+msgstr "Du kannst nicht mehr als %d Benutzern folgen."
 
 msgid "RANKING"
 msgstr "Ranking"
@@ -182,32 +182,31 @@ msgid "TICKET_SECTION"
 msgstr "Tickets"
 
 msgid "DRAW_REGULAR_TICKET"
-msgstr "Draw Ticket"
+msgstr "Ticket ziehen"
 
 msgid "CAN_DRAW_TICKET_SUBTEXT"
-msgstr "You can draw a regular ticket! You might win a prize."
+msgstr "Du kannst ein normales Ticket ziehen! Mit etwas Glück gewinnst du einen Preis."
 
 msgid "INVENTORY"
-msgstr "Inventory"
+msgstr "Inventar"
 
 msgid "TICKET_COOLDOWN_MESSAGE_FORMAT"
-msgstr "You can draw another ticket in: %s hour(s) %s minute(s)."
+msgstr "Du kannst ein weiteres Ticket ziehen in: %s Stunde(n) %s Minute(n)."
 
 msgid "REDEEM"
-msgstr "Redeem"
-
+msgstr "Einlösen"
 
 msgid "SPENDABLE_STARS"
-msgstr "Your Stars"
+msgstr "Deine Sterne"
 
 msgid "SPENDABLE_STARS_HELPTEXT"
-msgstr "Stars to add to Flipnotes or use for themes"
+msgstr "Sterne zum Bewerten von Flipnotes / Erwerben von Kulissen"
 
 msgid "LOGIN_REQUIRED_ACTION"
-msgstr "You must be logged in to perform this action."
+msgstr "Du musst eingeloggt sein, um diese Aktion auszuführen."
 
 msgid "PAGE"
-msgstr "Page"
+msgstr "Seite"
 
 msgid "PAGE_COUNTER_FORMAT"
-msgstr "%d of %d"
+msgstr "%d von %d"

--- a/de_DE/LC_MESSAGES/dailyStarReport.po
+++ b/de_DE/LC_MESSAGES/dailyStarReport.po
@@ -1,20 +1,20 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] %s's Daily Star Report"
+msgstr "[Sudomemo] %s's Täglicher Sterne-Bericht"
 
 msgid "STRING_SUDOMEMO"
 msgstr "Sudomemo"
 
 msgid "STRING_DAILY_STAR_REPORT"
-msgstr "Daily Star Report"
+msgstr "Täglicher Sterne-Bericht"
 
 msgid "TEXT_STAR_REPORT_GREETING_FORMAT"
-msgstr "Hello, %s! This is your Daily Star Report from Sudomemo."
+msgstr "Hallo, %s! Dies ist dein Täglicher Sterne-Bericht von Sudomemo."
 
 msgid "TEXT_FLIPNOTE_BY_FORMAT"
-msgstr "Flipnote by %s"
+msgstr "Flipnote von %s"
 
 msgid "TEXT_TOTAL_STARS_RECEIVED_TODAY"
-msgstr "Total Stars received today"
+msgstr "Summe der heute erhaltenen Sterne"
 
 msgid "TEXT_HOW_TO_VIEW_STAR_ADDERS_DSI"
-msgstr "Using your Nintendo DSi System, you can see who added Stars by tapping <strong>Stars</strong> in your Flipnote's details page on Sudomemo."
+msgstr "Mit deinem Nintendo DSi oder Nintendo 3DS kannst du einsehen, welche Nutzer dein Flipnote mit Sternen bewertet haben, indem du in den Flipnote-Details auf <strong>Sterne</strong> tippst."

--- a/de_DE/LC_MESSAGES/detailsPage.po
+++ b/de_DE/LC_MESSAGES/detailsPage.po
@@ -1,5 +1,5 @@
 msgid "TIMESTAMP_FORMAT"
-msgstr "M T, J H:i:s"
+msgstr "j. M y, H:i:s"
 
 msgid "FLIPNOTE_TITLE_FORMAT"
 msgstr "Flipnote von %s"
@@ -11,16 +11,16 @@ msgid "HEADER_COMMENTS"
 msgstr "Kommentare"
 
 msgid "HEADER_THIS_FLIPNOTE_IS_A_SPINOFF"
-msgstr "Dieser Flipnote ist ein spin-off."
+msgstr "Dieses Flipnote ist ein Spin-Off."
 
 msgid "HEADER_ORIGINAL_FLIPNOTE"
-msgstr "Rufe die original Flipnote hier auf!"
+msgstr "Rufe das Original-Flipnote hier auf!"
 
 msgid "HEADER_NO_STARBEGGING_STAR_LIMIT"
-msgstr "Um Sterne-bätteln zu verhindern haben wir die anzahl Gelber Sterne auf 10 limitiert."
+msgstr "Um gegen Sternebettlerei vorzugehen haben wir die Anzahl Gelber Sterne auf 10 begrenzt."
 
 msgid "HEADER_CREATOR"
-msgstr "Creator"
+msgstr "Ersteller"
 
 msgid "HEADER_STARS"
 msgstr "Sterne"
@@ -29,7 +29,7 @@ msgid "HEADER_VIEWS"
 msgstr "Aufrufe"
 
 msgid "HEADER_SPINOFFS"
-msgstr "Spin-offs"
+msgstr "Spin-Offs"
 
 msgid "HEADER_DOWNLOADS"
 msgstr "Downloads"
@@ -41,10 +41,10 @@ msgid "HEADER_POSTED"
 msgstr "Hochgeladen"
 
 msgid "HEADER_FLIPNOTE_ID"
-msgstr "Flipnote ID"
+msgstr "Flipnote-ID"
 
 msgid "HEADER_CHANNEL"
-msgstr "Channel"
+msgstr "Kanal"
 
 msgid "HEADER_OPTIONS"
 msgstr "Optionen"
@@ -53,10 +53,10 @@ msgid "HEADER_SET_AS_PROFILE_PICTURE"
 msgstr "Als Profilbild einstellen"
 
 msgid "HEADER_REPORT_FLIPNOTE"
-msgstr "Flipnote Melden"
+msgstr "Flipnote melden"
 
 msgid "ADMIN_ACTIONS"
-msgstr "Admin Aktionen"
+msgstr "Admin-Aktionen"
 
 msgid "PREV"
 msgstr "Zurück"
@@ -68,43 +68,43 @@ msgid "STAR_DETAILS_UPPERTITLE"
 msgstr "★ Sterne ★"
 
 msgid "SET_TITLE"
-msgstr "Set Title"
+msgstr "Titel einstellen"
 
 msgid "SET_TITLE_INSTRUCTIONS"
-msgstr "Enter the new title for your Flipnote below."
+msgstr "Den neuen Titel deines Flipnotes hier unten eingeben."
 
 msgid "40_CHARACTER_LIMIT"
-msgstr "Your title is limited to 40 characters in length."
+msgstr "Die Länge deines Titels ist auf 40 Charaktere begrenzt."
 
 msgid "LEAVE_BLANK_TO_RESET"
-msgstr "To reset the title to default, leave the form blank when submitting."
+msgstr "Der Titel kann beim Speichern ohne Text zurückgesetzt werden."
 
 msgid "ENTER_TITLE"
-msgstr "Enter title..."
+msgstr "Titel eingeben..."
 
 msgid "HEADER_ADD_DESCRIPTION"
-msgstr "Add Description"
+msgstr "Beschreibung hinzufügen"
 
 msgid "HEADER_DESCRIPTION"
-msgstr "Description"
+msgstr "Beschreibung"
 
 msgid "SET_DESCRIPTION"
-msgstr "Set Description"
+msgstr "Beschreibung einstellen"
 
 msgid "SET_DESCRIPTION_INSTRUCTIONS"
-msgstr "Enter the new description for your Flipnote below."
+msgstr "Die neue Beschreibung deines Flipnotes hier unten eingeben."
 
 msgid "101_CHARACTER_LIMIT_DESC"
-msgstr "Your description is limited to 101 characters in length."
+msgstr "Die Länge deiner Beschreibung ist auf 101 Charaktere begrenzt."
 
 msgid "LEAVE_BLANK_TO_RESET_DESC"
-msgstr "To remove the description, leave the form blank when submitting."
+msgstr "Die Beschreibung kann beim Speichern ohne Text zurückgesetzt werden."
 
 msgid "ENTER_DESCRIPTION"
-msgstr "Enter description..."
+msgstr "Beschreibung eingeben..."
 
 msgid "HEADER_FLIPNOTE_OPTIONS"
-msgstr "Options"
+msgstr "Optionen"
 
 msgid "HEADER_SONG"
 msgstr "Song"

--- a/de_DE/LC_MESSAGES/emailVerificationReminder.po
+++ b/de_DE/LC_MESSAGES/emailVerificationReminder.po
@@ -1,19 +1,17 @@
 msgid "EMAIL_SUBJECT"
-msgstr "[Sudomemo] You need to verify your email address"
+msgstr "[Sudomemo] Du musst deine Email-Adresse bestätigen"
 
 msgid "VERIFICATION_HEADER"
-msgstr "Sudomemo - Verify Email"
+msgstr "Sudomemo - Email-Bestätigung"
 
 msgid "TEXT_HELLO_FORMAT"
-msgstr "Hello, %s!"
+msgstr "Hallo, %s!"
 
 msgid "TEXT_NEED_TO_VERIFY_EMAIL"
-msgstr "This is a reminder that you need to verify your email address on Sudomemo."
+msgstr "Dies ist eine Erinnerung daran, dass du deine Email-Adresse auf Sudomemo noch bestätigen musst."
 
 msgid "TEXT_LOGIN_WITH_DSI_TO_VERIFY"
-msgstr "You can have a new verification email sent to you by logging into Sudomemo with your Nintendo DSi System."
+msgstr "Du kannst eine neue Bestätigungs-Mail durch das Anmelden auf Sudomemo auf deinem Nintendo DSi oder Nintendo 3DS erhalten."
 
 msgid "TEXT_NEED_HELP_CONNECTION_INFO_LINK_FORMAT"
-msgstr "Need help connecting to Sudomemo? The setup guide can be found here: %s"
-
-
+msgstr "Benötigst du Hilfe zur Verbindung mit Sudomemo? Hier findest du die Einrichtungs-Anleitung: %s"

--- a/de_DE/LC_MESSAGES/flipnoteComments.po
+++ b/de_DE/LC_MESSAGES/flipnoteComments.po
@@ -17,28 +17,28 @@ msgid "PAGE_FORMAT"
 msgstr "Seite %d"
 
 msgid "NO_COMMENTS_YET"
-msgstr "Dieser Flipnote hat noch keine Kommentare."
+msgstr "Dieses Flipnote hat noch keine Kommentare."
 
 msgid "LOGIN_REQUIRED_TO_POST_COMMENT"
-msgstr "Du musst ein geloggt sein um ein Kommentar zu posten."
+msgstr "Du musst eingeloggt sein um, einen Kommentar zu versenden."
 
 msgid "COMMENT_POST_FAILED"
-msgstr "Hochladen des Kommentars ist fehlgeschlagen! Versuche es später erneut!"
+msgstr "Senden des Kommentars fehlgeschlagen! Versuche es später erneut."
 
 msgid "NO_BLANK_COMMENTS_ALLOWED"
-msgstr "Du kannst kein leeren Kommentar posten."
+msgstr "Du kannst keinen leeren Kommentar posten."
 
 msgid "FLIPNOTE_DATA_CORRUPTED"
-msgstr "Die Flipnote Datei ist beschädigt! Versuche es später erneut."
+msgstr "Die Flipnote-Datei ist beschädigt! Versuche es später erneut."
 
 msgid "FLIPNOTE_COMMENTS_DISALLOWED"
-msgstr "Du darfst kein Kommentar an diesen Flipnote posten."
+msgstr "Du darfst keinen Kommentar an dieses Flipnote posten."
 
 msgid "NO_COMMENTS_WHILE_MUTED"
-msgstr "Du wurdest stummgeschalten! Du kannst keine Kommentare posten."
+msgstr "Du wurdest stummgeschalten! Du kannst keine Kommentare versenden, wenn du stummgeschalten wurdest."
 
 msgid "DUPLICATE_COMMENT_FAILED"
-msgstr "Dieser Kommentar wurde schon in Sudomemo hochgeladen."
+msgstr "Dieser Kommentar wurde schon in Sudomemo gepostet."
 
 msgid "COMMENT_FAILED_USER_BANNED"
 msgstr "Du wurdest von Sudomemo gebannt."

--- a/de_DE/LC_MESSAGES/flipnoteOptions.po
+++ b/de_DE/LC_MESSAGES/flipnoteOptions.po
@@ -43,7 +43,7 @@ msgstr "Tippe den Status einer Option an, um sie zu verwalten."
 msgid "OPTION_NAME_FORCE_44K_BITRATE"
 msgstr "Audio-Korrektur"
 
-msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
+msgid "OPTION_DESC_FORCE_44K_BITRATE"
 msgstr "Sudomemo wird versuchen, Audio von Flipnotes klarer und sauberer über Sudomemo Theatre abzuspielen."
 
 msgid "ENABLE_AUDIO_ENHANCEMENT"

--- a/de_DE/LC_MESSAGES/flipnoteOptions.po
+++ b/de_DE/LC_MESSAGES/flipnoteOptions.po
@@ -1,11 +1,11 @@
 msgid "FLIPNOTE_OPTIONS"
-msgstr "Flipnote Options"
+msgstr "Flipnote-Optionen"
 
 msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
-msgstr "You must be logged in to view this page."
+msgstr "Du musst angemeldet sein, um diese Seite zu sehen."
 
 msgid "HEADER_OPTION"
-msgstr "Option"
+msgstr "Optionen"
 
 msgid "HEADER_STATUS"
 msgstr "Status"
@@ -14,41 +14,41 @@ msgid "OPTION_NAME_SMOOTH"
 msgstr "Smoothing"
 
 msgid "OPTION_DESC_SMOOTH"
-msgstr "Lines, curves, and edges are smoothed for a more natural look on Sudomemo Theatre."
+msgstr "Linien, Kurven und Kanten werden in Sudomemo Theatre abgerundet, um einen natürlicheren Effekt wiederzugeben."
 
 msgid "FLIPNOTE_URL_IS"
-msgstr "Flipnote URL:"
+msgstr "Flipnote-URL:"
 
 msgid "ENABLE_SMOOTHING"
-msgstr "Enable smoothing"
+msgstr "Smoothing einschalten"
 
 msgid "DISABLE_SMOOTHING"
-msgstr "Disable smoothing"
+msgstr "Smoothing ausschalten"
 
 msgid "ON"
-msgstr "On"
+msgstr "Ein"
 
 msgid "OFF"
-msgstr "Off"
+msgstr "Aus"
 
 msgid "CITIZENSHIP_REQUIRED"
-msgstr "You'll need Sudomemo Citizenship to use this feature."
+msgstr "Du benötigst eine Sudomemo-Bürgerschaft, um dieses Feature zu nutzen."
 
 msgid "PLUS_REQUIRED"
-msgstr "You'll need Sudomemo Plus to use this feature."
+msgstr "Du benötigst Sudomemo Plus, um dieses Feature zu nutzen."
 
 msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
-msgstr "Tap on an option's status to view or change it."
+msgstr "Tippe den Status einer Option an, um sie zu verwalten."
 
 msgid "OPTION_NAME_FORCE_44K_BITRATE"
-msgstr "Enhanced audio"
+msgstr "Audio-Korrektur"
 
-msgid "OPTION_DESC_FORCE_44K_BITRATE"
-msgstr "Sudomemo will try to make your audio sound crisper and cleaner for Sudomemo Theatre."
+msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
+msgstr "Sudomemo wird versuchen, Audio von Flipnotes klarer und sauberer über Sudomemo Theatre abzuspielen."
 
 msgid "ENABLE_AUDIO_ENHANCEMENT"
-msgstr "Enable audio enhancement"
+msgstr "Audioverbesserung einschalten"
 
 msgid "DISABLE_AUDIO_ENHANCEMENT"
-msgstr "Disable audio enhancement"
+msgstr "Audioverbesserung ausschalten"
 

--- a/de_DE/LC_MESSAGES/followNotificationEmail.po
+++ b/de_DE/LC_MESSAGES/followNotificationEmail.po
@@ -1,17 +1,17 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] %s added you to their Favorites"
+msgstr "[Sudomemo] %s hat dich zu deinen Favoriten hinzugefügt"
 
 msgid "GREETING_FORMAT"
 msgstr "Hey %s!"
 
 msgid "NEW_FOLLOWER_ADDED_YOU_FORMAT"
-msgstr "%s just added you to their Favorites."
+msgstr "%s hat dich soeben zu deinen Favoriten hinzugefügt."
 
 msgid "STATS_FLIPNOTES_FORMAT"
 msgstr "%s Flipnotes"
 
 msgid "STATS_FOLLOWERS_FORMAT"
-msgstr "%s Followers"
+msgstr "%s Follower"
 
 msgid "STATS_FLIPNOTES_FORMAT_SINGULAR"
 msgstr "%s Flipnote"
@@ -20,5 +20,4 @@ msgid "STATS_FOLLOWERS_FORMAT_SINGULAR"
 msgstr "%s Follower"
 
 msgid "VIEW_PROFILE"
-msgstr "View Profile"
-
+msgstr "Profil ansehen"

--- a/de_DE/LC_MESSAGES/happyBirthdayEmail.po
+++ b/de_DE/LC_MESSAGES/happyBirthdayEmail.po
@@ -1,14 +1,14 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] Happy Birthday, %s!"
+msgstr "[Sudomemo] Alles Gute, %s!"
 
 msgid "GREETING_FORMAT"
 msgstr "Hey %s!"
 
 msgid "HAPPY_BIRTHDAY"
-msgstr "Happy birthday!"
+msgstr "Wir wünschen die alles Gute zum Geburtstag!"
 
 msgid "SPECIAL_SURPRISE_WAITING"
-msgstr "There's a special birthday surprise waiting for you on Sudomemo."
+msgstr "Eine spezielle Überraschung erwartet dich auf Sudomemo."
 
 msgid "LOGON_ON_DS_TO_VIEW"
-msgstr "Log on to Sudomemo with your Nintendo DSi or 3DS to receive your birthday gift!"
+msgstr "Melde dich auf deinem Nintendo DSi oder Nintendo 3DS bei Sudomemo an, um dein Geschenk zu erhalten!"

--- a/de_DE/LC_MESSAGES/inbox.po
+++ b/de_DE/LC_MESSAGES/inbox.po
@@ -3,7 +3,7 @@ msgstr "Inbox"
 
 # this must be a max of 6 characters
 msgid "UNAUTHED_READ"
-msgstr "Lesen."
+msgstr "Lesen"
 
 msgid "PREV"
 msgstr "Zurück"

--- a/de_DE/LC_MESSAGES/login.po
+++ b/de_DE/LC_MESSAGES/login.po
@@ -2,43 +2,43 @@ msgid "BAN_GREETING_FORMAT"
 msgstr "Hallo, %s."
 
 msgid "BAN_NOTICE_CONSOLE_BAN"
-msgstr "Dein Account + Konsole wurde von Sudomemo gebannt."
+msgstr "Sowohl dein Konto als auch deine Konsole wurden von Sudomemo gebannt."
 
 msgid "BAN_NOTICE_PLEASE_READ_BAN_LETTER"
-msgstr "Bitte lese die mail die wir geschickt haben für weitere Information."
+msgstr "Bitte lese die von uns gelieferte Email für weitere Informationen."
 
 msgid "BAN_VIEW_MAIL"
-msgstr "Sudomemo Mail Sehen"
+msgstr "Sudomemo-Mail sehen"
 
 msgid "LOGIN_SUCCESSFUL"
 msgstr "Login erfolgreich"
 
 msgid "THANKS_FOR_LOGIN_FORMAT"
-msgstr "Danke für's einloggen, %s!"
+msgstr "Danke für's Einloggen, %s!"
 
 msgid "GOTO_CREATORS_ROOM"
-msgstr "Geh zu dein Creator's Room"
+msgstr "Geh zu deinem Ersteller-Raum"
 
 msgid "LOGIN"
 msgstr "Login"
 
 msgid "POST_COMMENT_BELOW"
-msgstr "Um fortzufahren bitte hinterlasse ein Kommentar."
+msgstr "Bitte hinterlasse ein Kommentar um fortzufahren."
 
 msgid "LOGIN_SETUP"
-msgstr "Login Setup"
+msgstr "Login-Setup"
 
 msgid "WELCOME_BACK_FORMAT"
 msgstr "Willkommen zurück, %s!"
 
 msgid "RETURNING_USER_NEW_LOGIN_SYSTEM"
-msgstr "Seit letztes mal als du online warst haben wir jetzt ein neues Login-system, aber keine Sorge! All deine Flipnotes sind noch da!"
+msgstr "Wir haben seit deinem letzten Besuch ein neues Login-System eingerichtet, aber keine Sorge! All deine Inhalte sind stets vorhanden!"
 
 msgid "RETURNING_USER_PLEASE_CREATE_PASSWORD"
-msgstr "Um fortzufahren bitte erstelle ein Passwort."
+msgstr "Bitte erstelle ein Passwort um fortzufahren."
 
 msgid "NEW_USER_WELCOME_FORMAT"
-msgstr "Willkommen zu Sudomemo, %s!"
+msgstr "Willkommen bei Sudomemo, %s!"
 
 msgid "NEW_USER_PLEASE_CREATE_PASSWORD"
 msgstr "Bitte erstelle ein neues Passwort."
@@ -47,34 +47,34 @@ msgid "FORM_HEADER_PASSWORD"
 msgstr "Passwort:"
 
 msgid "FORM_PREFILL_PASSWORD"
-msgstr "Gebe dein Passwort hier ein..."
+msgstr "Gib dein Passwort hier ein..."
 
 msgid "FORM_WARNING_PASSWORD_TOO_SHORT"
-msgstr "Bitte gib ein Passwort an das länger als 8 Zeichen sind."
+msgstr "Stelle bitte sicher, dass das Passwort mehr als 8 Charaktere enthält."
 
 msgid "FORM_WARNING_PASSWORD_DISALLOWED_CHARS"
 msgstr "Dein Passwort kann diese Zeichen nicht enthalten:"
 
 msgid "FORM_LABEL_DONT_FORGET_PASSWORD"
-msgstr "Erinnerung: Mach eine Erinnerung für dein passwort und halte es geheim!"
+msgstr "Erstelle eine Notiz für dein Passwort, und halte es geheim!"
 
 msgid "FORM_HEADER_EMAIL"
 msgstr "Email (Optional):"
 
 msgid "FORM_PREFILL_EMAIL"
-msgstr "Gib deine Email hier an..."
+msgstr "Bitte deine Email hier eingeben."
 
 msgid "FORM_WARNING_EMAIL_INVALID"
-msgstr "Die Email ist nicht richtig."
+msgstr "Die eingegebene Email ist ungültig."
 
 msgid "EMAIL_ADDITION_SUGGESTED"
-msgstr "Die Email ist Optional aber du brauchst es damit wir falls du dein passwort vergisst eine Wiederherstellungs Email schicken können."
+msgstr "Die Eingabe der Email-Adresse ist optional, jedoch ist sie für Wiederherstellungs-Emails nötig, falls du dein Passwort vergessen hast."
 
 msgid "CONFIRM_INFO_CORRECT"
-msgstr "Bitte stell sicher das die Information ist correct."
+msgstr "Bitte stelle sicher, ob die eingegebene Information korrekt ist."
 
 msgid "NO_PLAINTEXT_PASSWORD_RECOVERY_IF_LOST"
-msgstr "Danach können wir dein Passwort nicht mehr wiederherstellen."
+msgstr "Hiernach können wir dein Passwort kein erneutes Mal wiederherstellen."
 
 msgid "BUTTON_CHANGE_PASSWORD"
 msgstr "Passort ändern"
@@ -83,25 +83,25 @@ msgid "FORM_HEADER_EMAIL_CONFIRM"
 msgstr "Email:"
 
 msgid "BUTTON_CHANGE_EMAIL"
-msgstr "Email Adresse umändern"
+msgstr "Email-Adresse ändern"
 
 msgid "BUTTON_ADD_AN_EMAIL_ADDRESS"
-msgstr "Email adresse hinzufügen"
+msgstr "Email-Adresse hinzufügen"
 
 msgid "BUTTON_SUBMIT"
 msgstr "Einreichen"
 
 msgid "PLEASE_ENTER_PASSWORD_TO_SIGN_IN"
-msgstr "Bitte gib dein Passwort an um dich einzuloggen"
+msgstr "Bitte dein Passwort eingeben, um dich einzuloggen"
 
 msgid "LOGIN_FORM_PREFILL_PASSWORD"
 msgstr "Passwort eingeben"
 
 msgid "INCORRECT_PASSWORD_ATTEMPTS_FORMAT"
-msgstr "Incorrecte passwörter: %s"
+msgstr "Inkorrekte Passwörter: %s"
 
 msgid "REGISTRATION_ERROR_BAD_EMAIL"
-msgstr "Die Email die du angegeben ist nicht zulässig."
+msgstr "Die von dir angegebene Email-Adresse ist nicht zulässig."
 
 msgid "REGISTRATION_ERROR_BAD_PASSWORD"
 msgstr "Dieses Passwort ist nicht zulässig."
@@ -113,25 +113,25 @@ msgid "REGISTRATION_ERROR_PASSWORD_ALREADY_SET"
 msgstr "Passwort wurde schon eingestellt."
 
 msgid "NEW_USER_THANKS_FOR_REGISTRATION"
-msgstr "Willkommen in Sudomemo!"
+msgstr "Willkommen auf Sudomemo!"
 
 msgid "RETURNING_USER_THANKS_FOR_REGISTRATION"
-msgstr "Willkommen zurück! Danke dass du deine login information einzustellen."
+msgstr "Willkommen zurück! Vielen Dank für deine Registrierung!"
 
 msgid "BUTTON_SIGN_IN_TO_SUDOMEMO"
-msgstr "In Sudomemo einloggen"
+msgstr "Auf Sudomemo einloggen"
 
 msgid "LOGIN_FAILED"
 msgstr "Login fehlgeschlagen."
 
 msgid "LOGIN_FAILED_REOPEN_FLIPNOTE_STUDIO"
-msgstr "Login fehlgeschlagen. Starte Flipnote Studio neu."
+msgstr "Login fehlgeschlagen. Bitte starte Flipnote Studio erneut."
 
 msgid "LOGIN_FAILED_CORRUPTED_DATA_LINE1"
-msgstr "Die Flipnote Datei ist beschädigt."
+msgstr "Die Flipnote-Datei ist beschädigt."
 
 msgid "LOGIN_FAILED_CORRUPTED_DATA_LINE2"
-msgstr "Versuche es erneut zu senden."
+msgstr "Versuche, sie erneut zu senden."
 
 msgid "LOGIN_FAILED_BANNED_LINE1"
 msgstr "Du wurdest von Sudomemo gebannt."
@@ -143,8 +143,7 @@ msgid "CREATORS_ROOM_SHIM_WELCOME"
 msgstr "Willkommen!"
 
 msgid "CREATORS_ROOM_SHIM_PLEASE_LOGIN"
-msgstr "Willkommen zu Sudomemo! Melde dich an um fortzufahren."
+msgstr "Willkommen auf Sudomemo! Melde dich an um fortzufahren."
 
 msgid "NEW_USER_INTRO_POST_INTRO_CHANNEL"
-msgstr "When you're ready, go ahead and introduce yourself in our Introduction channel, under the Personal category."
-
+msgstr "Wenn du bereit bist, gib dich der Welt im Vorstelleungs-Kanal in der Personal-Kategorie preis."

--- a/de_DE/LC_MESSAGES/mailSettings.po
+++ b/de_DE/LC_MESSAGES/mailSettings.po
@@ -1,102 +1,101 @@
 msgid "HEADER_MAIL_SETTINGS"
-msgstr "Mail Settings"
+msgstr "Mail-Einstellungen"
 
 msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
-msgstr "You must be logged in to edit your mail settings."
+msgstr "Du musst angemeldet sein, um deine Mail-Einstellungen zu ändern."
 
 msgid "MAIL_TYPE"
-msgstr "Type"
+msgstr "Mail-Typ"
 
 msgid "MAIL_STATUS"
 msgstr "Status"
 
 msgid "ENABLED"
-msgstr "Enabled"
+msgstr "Eingeschaltet"
 
 msgid "DISABLED"
-msgstr "Disabled"
+msgstr "Ausgeschaltet"
 
 msgid "ENABLE"
-msgstr "Enable"
+msgstr "Einschalten"
 
 msgid "Disable"
-msgstr "Disable"
+msgstr "Ausschalten"
 
 msgid "TAP_TO_ENABLE"
-msgstr "Tap to enable"
+msgstr "Hier zum Einschalten tippen"
 
 msgid "TAP_TO_DISABLE"
-msgstr "Tap to disable"
+msgstr "Hier zum Ausschalten tippen"
 
 msgid "TYPE_NEWS_NAME"
 msgstr "Sudomemo News"
 
 msgid "TYPE_NEWS_DESC"
-msgstr "Receive an email when something new is posted to the Sudomemo News"
+msgstr "Erhalte Emails über neue Beiträge in Sudomemo News"
 
 msgid "TYPE_PROMO_NAME"
-msgstr "Service Updates"
+msgstr "Dienst-Updates"
 
 msgid "TYPE_PROMO_DESC"
-msgstr "Receive emails about new features, tips and tricks, and upcoming events!"
+msgstr "Erhalte Emails über neue Features, Tipps und Tricks sowie zukünftige Events!"
 
 msgid "TYPE_FAVE_NOTIF_NAME"
-msgstr "Added as Favorite"
+msgstr "Zu Favoriten hinzugefügt"
 
 msgid "TYPE_FAVE_NOTIF_DESC"
-msgstr "Receive an email when someone adds you to their Favorites"
+msgstr "Erhalte eine Email, wenn jemand dich zu seinen Favoriten hinzufügt"
 
 msgid "TYPE_COMMENT_NOTIF_NAME"
-msgstr "Comment Received"
+msgstr "Kommentar erhalten"
 
 msgid "TYPE_COMMENT_NOTIF_DESC"
-msgstr "Receive an email when someone comments on your Flipnote"
+msgstr "Erhalte eine Email, wenn jemand dein Flipnote einen Kommentar versendet"
 
 msgid "TYPE_STAR_REPORT_NAME"
-msgstr "Daily Star Report"
+msgstr "Täglicher Sternenbericht"
 
 msgid "TYPE_STAR_REPORT_DESC"
-msgstr "Receive an email at the end of the day about any stars you've received"
+msgstr "Erhalte täglich eine Email mit einem Überblick auf die im Tag erhaltenen Sterne"
 
 msgid "TYPE_SPINOFF_NOTIF_NAME"
-msgstr "Spin-off Received"
+msgstr "Spin-Off erhalten"
 
 msgid "TYPE_SPINOFF_NOTIF_DESC"
-msgstr "Receive an email when someone posts a spin-off to your Flipnote"
+msgstr "Erhalte eine Email, wenn ein Spin-off eines deiner Flipnotes hochgeladen wird"
 
 msgid "TYPE_SECURITY_NOTIF_NAME"
-msgstr "Account Security"
+msgstr "Konto-Sicherheit"
 
 msgid "TYPE_SECURITY_NOTIF_DESC"
-msgstr "Receive an email when your email address or password is updated"
+msgstr "Erhalte eine Email, wenn deine Email-Adresse oder dein Passwort aktualisiert wird"
 
 msgid "TYPE_REPORT_UPDATE_NAME"
-msgstr "Flagged Content Update"
+msgstr "Updates über gemeldete Inhalte"
 
 msgid "TYPE_REPORT_UPDATE_DESC"
-msgstr "Receive an email when we update the status of content that you've flagged"
+msgstr "Erhalte eine Email, wenn wir den Status der von dir gemeldeten Inhalte aktualisieren"
 
 msgid "TYPE_UNREAD_COMMENTS_NAME"
-msgstr "Unread Comments"
+msgstr "Ungelesene Kommentare"
 
 msgid "TYPE_UNREAD_COMMENTS_DESC"
-msgstr "Receive an email summary of any new comments you've received recently"
+msgstr "Erhalte eine zusammenfassende Email der neulich erhaltenen Kommentare"
 
 msgid "TAP_ON_STATUS_TO_VIEW_DETAILS"
-msgstr "Tap on a mail type's status to view or update it."
+msgstr "Tippe auf den Status eines Mail-Typs, um ihn zu verwalten."
 
 msgid "HEADER_CHANGE_EMAIL_SETTINGS"
-msgstr "Change Email Settings"
+msgstr "Email-Einstellungen bearbeiten"
 
 msgid "DISABLE_CONFIRMATION_FORMAT"
-msgstr "Are you sure you want to disable '%s' emails?"
+msgstr "Willst du sicherlich die Emails für '%s' abschalten?"
 
 msgid "REENABLE_INSTRUCTIONS"
-msgstr "If you want to turn them back on, you can do so from by selecting <strong>Email Settings</strong> in your Creator's Room."
+msgstr "Willst du sie wieder einschalten, so wähle die Option <strong>Mail-Einstellungen</strong> in deinem Ersteller-Raum."
 
 msgid "EMAIL_SETTING_DISABLED_FINISH_FORMAT"
-msgstr "You've disabled '%s' emails."
+msgstr "Du hast die Emails für '%s' abgeschaltet."
 
 msgid "EMAIL_CHANGE_TOKEN_EXPIRED"
-msgstr "The link you followed has expired."
-
+msgstr "Der eingegebene Link ist abgelaufen."

--- a/de_DE/LC_MESSAGES/menuHeaders.po
+++ b/de_DE/LC_MESSAGES/menuHeaders.po
@@ -1,17 +1,17 @@
 msgid "GET_STARTED"
-msgstr "Get Started"
+msgstr "Durchstarten"
 
 msgid "WATCH_FLIPNOTES"
 msgstr "Alle Flipnotes"
 
 msgid "CHANNELS"
-msgstr "Channels"
+msgstr "Kanäle"
 
 msgid "CATEGORIES"
 msgstr "Kategorien"
 
 msgid "FEATURED"
-msgstr "Featured"
+msgstr "Schaugestellt"
 
 msgid "HOT_FLIPNOTES"
 msgstr "Heiße Flipnotes"
@@ -20,13 +20,13 @@ msgid "ABOUT_SUDOMEMO"
 msgstr "Über Sudomemo"
 
 msgid "CREATORS_ROOM"
-msgstr "Creator's Room"
+msgstr "Ersteller-Raum"
 
 msgid "NEWS"
 msgstr "Sudomemo News"
 
 msgid "CHATROOMS"
-msgstr "Chaträume"
+msgstr "Chat-Räume"
 
 msgid "SEARCH"
 msgstr "Suchen"
@@ -50,13 +50,13 @@ msgid "REGISTER"
 msgstr "Regristrieren"
 
 msgid "THEME_SHOP"
-msgstr "Theme Shop"
+msgstr "Kulissen-Shop"
 
 msgid "MAIL"
 msgstr "Mail"
 
 msgid "TEST_TRANSLATION"
-msgstr "English Translation"
+msgstr "Englische Übersetzung"
 
 msgid "HELP"
 msgstr "Hilfe"

--- a/de_DE/LC_MESSAGES/musicMatch.po
+++ b/de_DE/LC_MESSAGES/musicMatch.po
@@ -1,17 +1,17 @@
 msgid "HEADER_SONG_DETAILS"
-msgstr "Song Details"
+msgstr "Song-Details"
 
 # Song Name
 msgid "TITLE"
-msgstr "Title"
+msgstr "Titel"
 
 # Song Band/Artist
 msgid "ARTIST"
-msgstr "Artist"
+msgstr "Künstler"
 
 # Year song was published
 msgid "RELEASE_YEAR"
-msgstr "Released"
+msgstr "Erschienen"
 
 msgid "GENRE"
 msgstr "Genre"
@@ -22,21 +22,21 @@ msgid "FLIPNOTE_COUNT"
 msgstr "Flipnotes"
 
 msgid "BROWSE"
-msgstr "Browse"
+msgstr "Durchsuchen"
 
 msgid "SONG_ID"
-msgstr "Song ID"
+msgstr "Song-ID"
 
 msgid "LINK_YOUTUBE_SPOTIFY"
-msgstr "YouTube and Spotify links are available:"
+msgstr "YouTube-Link und Spotify-Link sind verfügbar:"
 
 msgid "LINK_YOUTUBE"
-msgstr "A YouTube link is available here:"
+msgstr "Verfügbarer YouTube-Link:"
 
 msgid "LINK_SPOTIFY"
-msgstr "A Spotify link is available here:"
+msgstr "Verfügbarer Spotify-Link:"
 
 # Creator instructions
 
 msgid "IF_SONG_INCORRECT"
-msgstr "If an incorrect song is shown on your Flipnote, you can update it on Sudomemo Theatre. To learn more, visit: https://flipnot.es/musicmatch"
+msgstr "Falls ein falscher Song bei deinem Flipnote angegeben ist, kannst du diesen auf Sudomemo Theatre ändern. Besuche https://flipnot.es/musicmatch für weitere Informationen."

--- a/de_DE/LC_MESSAGES/privateMessages.po
+++ b/de_DE/LC_MESSAGES/privateMessages.po
@@ -1,20 +1,20 @@
 msgid "NO_COMMENTS_YET"
-msgstr "Es gibt hier keine Nachrichten."
+msgstr "Es gibt hier noch keine Nachrichten."
 
 msgid "HEADER_DIRECT_MESSAGES"
-msgstr "Direkt Nachrichten"
+msgstr "Direkt-Nachrichten"
 
 msgid "HEADER_CONVERSATION_ID"
-msgstr "Konversations ID"
+msgstr "Gesprächs-ID"
 
 msgid "HEADER_PARTICIPANTS"
 msgstr "Teilnehmer"
 
 msgid "HEADER_UNREAD_COUNT"
-msgstr "Nicht gelesen"
+msgstr "Ungelesen"
 
 msgid "TAP_ON_CONVERSATION_ID_TO_JOIN_CHAT"
-msgstr "Tippe auf einer Konversations ID um den chat beizutreten."
+msgstr "Tippe auf eine Gesprächs-ID, um dem Chat beizutreten."
 
 msgid "HEADER_NEXT"
 msgstr "Weiter"
@@ -29,19 +29,19 @@ msgid "HEADER_REFRESH"
 msgstr "Neu laden"
 
 msgid "LOGIN_REQUIRED_TO_REPLY"
-msgstr "Du must eingeloggt sein um dieser Konversation zu antworten."
+msgstr "Du must angemeldet sein, um in diesem Gespräch zu antworten."
 
 msgid "REPLY_FAIL_USER_BANNED"
 msgstr "Du wurdest von Sudomemo gebannt."
 
 msgid "DUPLICATE_COMMENT_FAILED"
-msgstr "Dieser Kommentar wurde schon auf Sudomemo geposted."
+msgstr "Dieser Kommentar wurde schon auf Sudomemo gepostet."
 
 msgid "CHAT_REPLY_FAILED"
-msgstr "Chat Antwort fehlgeschlagen! Versuche es später erneut."
+msgstr "Chat-Antwort fehlgeschlagen! Versuche es später erneut."
 
 msgid "NO_BLANK_MESSAGES_ALLOWED"
 msgstr "Du kannst keine leere Nachricht versenden."
 
 msgid "FLIPNOTE_DATA_CORRUPTED"
-msgstr "Die Flipnote Dateiist beschädigt! Versuche es später erneut."
+msgstr "Die Flipnote-Datei ist beschädigt! Versuche es später erneut."

--- a/de_DE/LC_MESSAGES/profilePicture.po
+++ b/de_DE/LC_MESSAGES/profilePicture.po
@@ -20,11 +20,10 @@ msgid "RETURN_TO_FLIPNOTE"
 msgstr "Zu Flipnote zurückkehren"
 
 msgid "CREATORS_ROOM"
-msgstr "Creator's Room"
+msgstr "Ersteller-Raum"
 
 msgid "CANCEL"
 msgstr "Abbrechen"
 
 msgid "LOGIN_REQUIRED_TO_CHANGE"
-msgstr "You must be logged in to change your profile picture."
-
+msgstr "Du musst angemeldet sein, um dein Profilbild zu ändern."

--- a/de_DE/LC_MESSAGES/reportContent.po
+++ b/de_DE/LC_MESSAGES/reportContent.po
@@ -2,7 +2,7 @@ msgid "HEADER_REPORT_CONTENT"
 msgstr "Melden"
 
 msgid "CHAT_MESSAGE"
-msgstr "Chatraum Nachricht"
+msgstr "Chatraum-Nachricht"
 
 msgid "COMMENT"
 msgstr "Kommentar"
@@ -14,7 +14,7 @@ msgid "YOU_ARE_REPORTING_THIS_FORMAT"
 msgstr "Du meldest dies: %s:"
 
 msgid "USER_HAS_ALREADY_REPORTED_FORMAT"
-msgstr "Du hast da schon gemeldet: %s."
+msgstr "Du hast dies schon gemeldet: %s."
 
 msgid "HEADER_VIOLATION_CATEGORY"
 msgstr "Verstoß-Kategorie:"
@@ -23,34 +23,34 @@ msgid "FLIPNOTE_TITLE_FORMAT"
 msgstr "Flipnote von %s"
 
 msgid "CREATOR_FORMAT"
-msgstr "Creator: %s"
+msgstr "Ersteller: %s"
 
 msgid "NOTICE_REPORT_OTHER_ISSUES"
-msgstr "Diese Form ist nur um den Inhalt dieses Benutzers zu melden. Um das verhalten des Benutzers zu melden, oder andere probleme, bitte schicke eine email an unseren support:"
+msgstr "Dieses Formular dient ausschiließen dem Melden des Inhaltes. Um das Verhalten des Benutzers sowie sonstige Probleme zu melden, schicke bitte eine Email an unseren Support-Dienst:"
 
 msgid "REPORT_INSTRUCTIONS"
-msgstr "Bitte mach eine kurze beschreibung warum du denkst das dieser inhalt gegen die Sudomemo Nutzungsbedingungen verstößt. Wenn du es eingereicht hast tippe auf zurück."
+msgstr "Bitte gib deine zusammengefasste Meinung daruber, wie der gemeldete Inhalt gegen die Nutzungsrechtlinien Sudomemos verstößt. Tippe nach dem Einreichen auf Zurück."
 
 msgid "NO_BLANK_REPORTS"
-msgstr "Du kannst keine leere beschreibung einreichen."
+msgstr "Du kannst keine leere Meldung einreichen."
 
 msgid "LIMIT_ONE_REPORT"
-msgstr "Bitte beachte dass du diesen inhalt nur 1 mal melden kannst, weitere Meldungen von dir zu diesen inhalt wird nicht regristriert, also fasse alles in ein Kommentar ab."
+msgstr "Bitte beachte, dass du diesen Inhalt nur 1-mal melden kannst. Weitere von dir eingereichte Meldungen zu diesem Inhalt werden nicht regristriert. Fasse daher bitte alles in einem Kommentar zusammen."
 
 msgid "REPORT_EXPLANATION_FAILED"
-msgstr "Fehler beim einreichen der Meldung."
+msgstr "Ein Fehler beim Einreichen der Meldung ist aufgetreten."
 
 msgid "RESTRICTED_CANCEL"
-msgstr "Du kannst diesen Inhalt nicht melden da du von Sudomemo gebannt wurdest."
+msgstr "Du kannst diesen Inhalt nicht melden, da du von Sudomemo gebannt wurdest."
 
 msgid "HEADER_REASON"
 msgstr "Grund:"
 
 msgid "LOGIN_REQUIRED_TO_CONTINUE"
-msgstr "Du musst eingeloggt sein um fortzufahren."
+msgstr "Du musst angemeldet sein, um fortzufahren."
 
 msgid "LOGIN_REQUIRED_TO_REPORT_CONTENT"
-msgstr "Du musst eingeloggt sein um irgendein Inhalt zu melden."
+msgstr "Du musst angemeldet sein, um Inhalte zu melden."
 
 msgid "REPORT_FAILED_USER_BANNED"
 msgstr "Du wurdest von Sudomemo gebannt."
@@ -59,5 +59,4 @@ msgid "DUPLICATE_COMMENT_FAILED"
 msgstr "Dieser Kommentar wurde schon auf Sudomemo hochgeladen."
 
 msgid "THANKS_FOR_REPORTING"
-msgstr "We've received your report. Thanks for helping make Sudomemo a better place!"
-
+msgstr "Wir haben deine Meldung erfolgreich erhalten. Vielen Dank für deine Kooperation zur Aufrechterhaltung von Sudomemo!"

--- a/de_DE/LC_MESSAGES/search.po
+++ b/de_DE/LC_MESSAGES/search.po
@@ -20,10 +20,10 @@ msgid "SEARCH_USERNAME"
 msgstr "Benutzername suchen"
 
 msgid "PLEASE_ENTER_USERNAME"
-msgstr "Bitte gib ein Benutzernamen ein..."
+msgstr "Bitte gib einen Benutzernamen ein..."
 
 msgid "RESULTS_FOUND_FORMAT_SINGULAR"
-msgstr "%1$d Ergebniss gefunden für \"%2$s\""
+msgstr "%1$d Ergebnis gefunden für \"%2$s\""
 
 msgid "RESULTS_FOUND_FORMAT_MULTIPLE"
 msgstr "%1$d Ergebnisse gefunden für \"%2$s\""
@@ -32,13 +32,13 @@ msgid "NO_RESULTS_FOUND"
 msgstr "Keine Ergebnisse gefunden"
 
 msgid "SEARCH_SHORT_KEY"
-msgstr "Flipnote ID"
+msgstr "Flipnote-ID"
 
 msgid "SHORT_KEY_NO_RESULTS"
-msgstr "No Flipnote found"
+msgstr "Keine Suchergebnisse"
 
 msgid "SHORT_KEY_FORMAT_GUIDE"
-msgstr "Not finding what you're looking for? You may have entered the Flipnote ID incorrectly. Flipnote IDs are six digits long and can be found in the details section for the Flipnote."
+msgstr "Du findest nicht, wonach du suchst? Du hast womöglich die falsche Flipnote-ID eingegeben. Flipnote-IDs betragen eine Länge von 6 Charakteren und können in den Details von Flipnotes aufgefunden werden."
 
 msgid "SHORT_KEY_SIMILAR_FOUND_CASE_SENSITIVE"
-msgstr "No result was found, but a similar ID exists. Please note that Flipnote IDs are case-sensitive, and usually all-capital letters and numbers."
+msgstr "Es wurden keine Suchergebnisse gefunden, aber es existiert eine ähnliche Flipnote-ID. Bitte beachte, dass Flipnote-IDs Groß- und Kleinschreibung beachten und gewöhnlicherweise nur aus Großbuchstaben und Ziffern bestehen."

--- a/de_DE/LC_MESSAGES/sudomemoNewsBrowser.po
+++ b/de_DE/LC_MESSAGES/sudomemoNewsBrowser.po
@@ -8,4 +8,4 @@ msgid "PAGE_FORMAT"
 msgstr "Seite %d"
 
 msgid "HEADER_NEWS"
-msgstr "News"
+msgstr "Neuigkeiten"

--- a/de_DE/LC_MESSAGES/sudomemoPlus.po
+++ b/de_DE/LC_MESSAGES/sudomemoPlus.po
@@ -1,83 +1,83 @@
 # Sudomemo Plus Legacy Citizenship Activation
 msgid "SUDOMEMO_PLUS_LEGACY_HEADER"
-msgstr "Welcome to Sudomemo Plus!"
+msgstr "Willkommen zu Sudomemo Plus!"
 
 msgid "GREETING_LEGACY_ACTIVATE_FORMAT"
-msgstr "Hello, %s!"
+msgstr "Hallo, %s!"
 
 msgid "LEGACY_ACTIVATE_CITIZENSHIP_CHANGE"
-msgstr "Sudomemo Citizenship has gone away, replaced by Sudomemo Plus!"
+msgstr "Sudomemo-Bürgerschaft wurde zugunsten von Sudomemo Plus abgesetzt!"
 
 msgid "LEGACY_ACTIVATE_PLUS_TEASER"
-msgstr "Sudomemo Plus gives you access to all sorts of extra features, such as smoothing and audio enhancement of your Flipnotes on Sudomemo Theatre, as well as colorful comments and other neat features!"
+msgstr "Sudomemo Plus gewährt dir Zugang zu mehreren neuer Features, wie u.A. die Abrundung und Audioverbesserung von Flipnotes in Sudomemo Theatre, sowie farbenfrohe Kommentare und mehr!"
 
 msgid "LEGACY_ACTIVATE_EARN_PLUS"
-msgstr "Sudomemo Plus can be earned by redeeming tickets purchased from our Shop or by entering a winning entry to our Weekly Topic."
+msgstr "Sudomemo Plus kann durch Einlösen von Tickets erhalten werden, die du durch Käufe oder als Preis zum Gewinn in Wochen-Themen bekommst."
 
 msgid "LEGACY_ACTIVATE_GRANDFATHERED_BONUS"
-msgstr "Since you previously had Citizenship, you've been given a month free of Sudomemo Plus. Make sure to take a look around and try out some fun new features!"
+msgstr "Da du Flipnote-Bürgerschaft hattest, erhälst du 3 Gratis-Monate Sudomemo Plus. Siehe dir die neuen tollen Features an und versuche sie aus!"
 
 msgid "CONTINUE"
-msgstr "Continue"
+msgstr "Weiter"
 
 # My Sudomemo Plus
 
 msgid "MANAGE_PLUS_HEADER"
-msgstr "My Sudomemo Plus"
+msgstr "Mein Sudomemo Plus"
 
 msgid "MANAGE_PLUS_REMAINING"
-msgstr "You currently have %s day(s) of Sudomemo Plus remaining."
+msgstr "Du hast noch %s Tag(e) Sudomemo Plus zur Verfügung."
 
 msgid "MANAGE_PLUS_HOW_TO_EARN_PLUS"
-msgstr "Sudomemo Plus can be earned by redeeming tickets purchased from our Shop or by entering a winning entry to our Weekly Topic."
+msgstr "Sudomemo Plus kann durch Einlösen von Tickets erhalten werden, die du durch Käufe oder als Preis zum Gewinn in Wochen-Themen bekommst."
 
 msgid "AVAILABLE_PLUS_FEATURES"
-msgstr "The following features are available through Sudomemo Plus. Make sure to check back here every once in a while!"
+msgstr "Diese Features sind mit Sudomemo Plus verfügbar. Wir schlagen dir vor, die Liste gelegentlich nachzusehen!"
 
 msgid "FOOTNOTE_PLATFORM_FEATURE_PARITY"
-msgstr "Please note that some features, such as Flipnote Smoothing and audio enhancement, can only be seen on Sudomemo Theatre."
+msgstr "Bitte beachte, dass einige Features wie Flipnote-Smoothing und Audio-Korrektur nur über Sudomemo Theatre verfügbar sind."
 
 msgid "FLIPNOTE_SMOOTHING"
-msgstr "Flipnote Smoothing"
+msgstr "Flipnote-Smoothing"
 
 msgid "FLIPNOTE_AUDIO_ENHANCEMENT"
-msgstr "Flipnote Audio Enhancement"
+msgstr "Flipnote-Audio-Enhancement"
 
 msgid "COLORFUL_COMMENTS"
-msgstr "Write colorful comments"
+msgstr "Farbene Kommentare schreiben"
 
 msgid "DOWNLOAD_YOUR_COMMENTS"
-msgstr "Download your comments as Flipnotes"
+msgstr "Kommentare als Flipnotes herunterladen"
 
 msgid "THEME_PUBLISHER_ACCESS"
-msgstr "Publish themes to the Theme Shop"
+msgstr "Kulissen im Kulissen-Shop hochladen"
 
 msgid "FLIPNOTE_ANALYTICS"
-msgstr "Access analytics information for your Flipnotes"
+msgstr "Auf Analytics-Infos für deine Flipnotes zugreifen"
 
 msgid "SUDOMEMO_GAME_ACCESS"
-msgstr "Play special games right on Sudomemo!"
+msgstr "Spiele spezielle Spiele direkt auf Sudomemo!"
 
 msgid "NO_THEATRE_ADS"
-msgstr "No advertisements on Sudomemo Theatre"
+msgstr "Keine Werbungen in Sudomemo Theatre"
 
 msgid "INCREASED_FOLLOW_LIMIT"
-msgstr "Increased follow limit - up to %s Creators"
+msgstr "Folge-Grenze bis auf %s Ersteller erhöht"
 
 # Sudomemo Plus Running Low Message
 
 msgid "PLUS_RUNNING_OUT_MSG_TITLE"
-msgstr "My Sudomemo Plus"
+msgstr "Mein Sudomemo Plus"
 
 msgid "PLUS_RUNNING_OUT_MSG_INTRO"
 msgstr "Hello, %s!"
 
 msgid "PLUS_RUNNING_OUT_MSG_DAYS_REMAINING_FORMAT"
-msgstr "This message is to let you know that you have %s days of Sudomemo Plus remaining."
+msgstr "Diese Nachricht wurde gesendet, um dich wissen zu lassen, dass du noch %s Tage Sudomemo Plus zur Verfügung hast."
 
 msgid "PLUS_RUNNING_OUT_MSG_HOW_TO_EARN_PLUS"
-msgstr "Don't forget that you can earn Sudomemo Plus by entering winning entries to the Weekly Topic, or by redeeming tickets purchased from our Shop."
+msgstr "Vergiss nicht, dass Sudomemo Plus durch Einlösen von Tickets erhalten werden kann, die du durch Käufe oder als Preis zum Gewinn in Wochen-Themen bekommst."
 
 msgid "PLUS_RUNNING_OUT_MSG_HAPPY_FLIPNOTING"
-msgstr "Happy Flipnoting!"
+msgstr "Frohes Flipnoting!"
 

--- a/de_DE/LC_MESSAGES/theatre.po
+++ b/de_DE/LC_MESSAGES/theatre.po
@@ -14,22 +14,22 @@ msgid "SUDOMEMO_SHOP"
 msgstr "Sudomemo Shop"
 
 msgid "SUDOMEMO_SHOP_META_DESCRIPTION"
-msgstr "Sudomemo Shop: Sudomemo merch, tickets for Plus and Stars, and other fun things!"
+msgstr "Sudomemo Shop: Sudomemo-Artikel, Tickets für Sudomemo Plus sowie Sterne und anderen spaßigen Produkten!"
 
 msgid "DEFAULT_META_DESCRIPTION"
-msgstr "Sudomemo: Share your Flipnotes with the world! For Nintendo DSi and 3DS."
+msgstr "Sudomemo: Teile deine Flipnotes mit der Welt! Für Nintendo DSi und Nintendo 3DS."
 
 msgid "FRONTPAGE_TITLE_TAGLINE"
-msgstr "Sudomemo: Flipnote Hatena is back!"
+msgstr "Sudomemo: Flipnote Hatena ist zurück!"
 
 msgid "VIEWPAGE_COMMENT_TEXTBOX"
-msgstr "Comment entry text box"
+msgstr "Textbox-Eintrag kommentieren"
 
 ## "Username - 3 fans, 25 Flipnotes on Sudomemo"
 ## Not going to bother making plural variants
 
 msgid "PROFILE_DEFAULT_DESCRIPTION"
-msgstr "%s - %s fans, %s Flipnotes on Sudomemo"
+msgstr "%s - %s Fan(s), %s Flipnote(s) auf Sudomemo"
 
 # Date-time formats
 # You can adjust the way dates display to match your region better.
@@ -40,48 +40,48 @@ msgstr "%s - %s fans, %s Flipnotes on Sudomemo"
 # Wednesday, December 3rd, 2019
 # Used for news articles
 msgid "DATETIME_WEEKDAY_MONTH_DAY_ORDINAL_YEAR_FORMAT"
-msgstr "l, F jS, Y"
+msgstr "l, j. F Y"
 
 # November 29th, 2019 08:23:07
 # Used for Flipnote Details
 msgid "DATETIME_MONTH_DAY_ORDINAL_HOUR_MINUTE_SECOND_FORMAT"
-msgstr "F jS, Y h:i:s"
+msgstr "j. F Y, h:i:s"
 
 # Very common terms and one-word translations
 
 msgid "ARTIST"
-msgstr "Artist"
+msgstr "Künstler"
 
 # Back, in the sense of navigation
 msgid "BACK"
-msgstr "Back"
+msgstr "Zurück"
 
 msgid "CATEGORY"
-msgstr "Category"
+msgstr "Kategorie"
 
 msgid "CHANNEL"
-msgstr "Channel"
+msgstr "Kanal"
 
 msgid "CHANNELS"
-msgstr "Channels"
+msgstr "Kanäle"
 
 msgid "COMMENTS"
-msgstr "Comments"
+msgstr "Kommentare"
 
 msgid "CREATOR"
-msgstr "Creator"
+msgstr "Ersteller"
 
 msgid "CREATORS"
-msgstr "Creators"
+msgstr "Ersteller"
 
 msgid "CREATORS_ROOM"
-msgstr "Creator's Room"
+msgstr "Ersteller-Raum"
 
 msgid "DETAILS"
 msgstr "Details"
 
 msgid "DESCRIPTION"
-msgstr "Description"
+msgstr "Beschreibung"
 
 msgid "DOWNLOADS"
 msgstr "Downloads"
@@ -90,10 +90,10 @@ msgid "FANS"
 msgstr "Fans"
 
 msgid "FEATURED"
-msgstr "Featured"
+msgstr "Vorgeschlagen"
 
 msgid "FLIPNOTE_ID"
-msgstr "Flipnote ID"
+msgstr "Flipnote-ID"
 
 msgid "FLIPNOTE"
 msgstr "Flipnote"
@@ -107,89 +107,88 @@ msgstr "FSID"
 
 # Japanese translation should also be be うごメモID here
 msgid "FLIPNOTE_STUDIO_ID"
-msgstr "Flipnote Studio ID"
+msgstr "Flipnote-Studio-ID"
 
 msgid "GENRE"
 msgstr "Genre"
 
 msgid "HELP_CENTER"
-msgstr "Help Center"
+msgstr "Hilfe-Zentrum"
 
 msgid "HOT"
-msgstr "Hot"
+msgstr "Heiß"
 
 msgid "INFO"
 msgstr "Info"
 
 msgid "LATEST"
-msgstr "Latest"
+msgstr "Neueste"
 
 msgid "MODERATOR"
 msgstr "Moderator"
 
 msgid "MORE"
-msgstr "More"
+msgstr "Mehr"
 
 msgid "MUSICMATCH"
 msgstr "MusicMatch"
 
 msgid "NEXT"
-msgstr "Next"
+msgstr "Weiter"
 
 msgid "NEWS"
 msgstr "News"
 
 # Channel permissions: Is posting Flipnotes to a channel allowed or not?
 msgid "PERMISSIONS"
-msgstr "Permissions"
+msgstr "Zulassungen"
 
 msgid "POPULAR"
-msgstr "Popular"
+msgstr "Beliebt"
 
 # Previous, abbreviated "Prev". Should be a maximum of 4 characters.
 msgid "PREV"
-msgstr "Prev"
+msgstr "Zur."
 
 msgid "RANDOM"
-msgstr "Random"
+msgstr "Zufällig"
 
 # Referring to a release date/publishing date
 msgid "RELEASED"
-msgstr "Released"
+msgstr "Erschienen"
 
 msgid "RANK"
-msgstr "Rank"
+msgstr "Rang"
 
 msgid "RECENT"
-msgstr "Recent"
+msgstr "Rezent"
 
 msgid "SAVE"
-msgstr "Save"
+msgstr "Speichern"
 
 msgid "SAVING"
-msgstr "Saving"
+msgstr "Speichern"
 
 msgid "SEARCH"
-msgstr "Search"
+msgstr "Suche"
 
 msgid "SHARE"
-msgstr "Share"
+msgstr "Teilen"
 
 msgid "SIGN_UP"
-msgstr "Sign Up"
+msgstr "Registrieren"
 
 msgid "SIGN_IN"
-msgstr "Sign in"
+msgstr "Anmelden"
 
 msgid "SIGN_OUT"
-msgstr "Sign out"
+msgstr "Abmelden"
 
 msgid "STARS"
-msgstr "Stars"
+msgstr "Sterne"
 
 msgid "TITLE"
-msgstr "Title"
-
+msgstr "Titel"
 
 # Referring to being the most popular (in terms of ranking)
 msgid "TOP"
@@ -197,7 +196,7 @@ msgstr "Top"
 
 # Number of times something has been viewed, or played.
 msgid "VIEWS"
-msgstr "Views"
+msgstr "Aufrufe"
 
 # For MusicMatch
 
@@ -210,34 +209,34 @@ msgstr "Sudomemo Plus"
 # Navbar
 
 msgid "NAVBAR_TOGGLE_NAVIGATION"
-msgstr "Toggle navigation"
+msgstr "Navigation umschalten"
 
 msgid "NAVBAR_ITEM_SHOP"
 msgstr "Shop"
 
 msgid "NAVBAR_ITEM_HELP"
-msgstr "Help"
+msgstr "Hilfe"
 
 msgid "NAVBAR_ITEM_USEFUL_LINKS"
-msgstr "Useful Links"
+msgstr "Nützliche Links"
 
 msgid "NAVBAR_ITEM_DISCORD"
 msgstr "Discord"
 
 msgid "NAVBAR_ITEM_HOW_TO_JOIN"
-msgstr "How to Join"
+msgstr "Wie Man Beitritt"
 
 msgid "NAVBAR_ITEM_CONNECTION_HELP"
-msgstr "Connection Help"
+msgstr "Verbindungs-Hilfe"
 
 msgid "NAVBAR_ITEM_FAQS"
 msgstr "FAQs"
 
 msgid "NAVBAR_ITEM_TERMS"
-msgstr "Terms of Use"
+msgstr "Nutzungsrechtlinien"
 
 msgid "NAVBAR_ITEM_CONTACT_US"
-msgstr "Contact Us"
+msgstr "Wende Dich an Uns!"
 
 msgid "NAVBAR_ITEM_TWITTER"
 msgstr "Twitter"
@@ -252,7 +251,7 @@ msgid "NAVBAR_ITEM_EMAIL"
 msgstr "Email"
 
 msgid "NAVBAR_ITEM_OTHER"
-msgstr "Other"
+msgstr "Sonstiges"
 
 msgid "NAVBAR_ITEM_CREDITS"
 msgstr "Credits"
@@ -264,140 +263,140 @@ msgid "NAVBAR_ITEM_SUDOMEMO_ADMIN"
 msgstr "Sudomin"
 
 msgid "NAVBAR_ITEM_REPORTED_FLIPNOTES"
-msgstr "Reported Flipnotes"
+msgstr "Gemeldete Flipnotes"
 
 msgid "NAVBAR_ITEM_SWITCH_TO_USER_ACCOUNT"
-msgstr "Switch to user account"
+msgstr "Zum Benutzer-Konto wechseln"
 
 ## Switch to dark mode
 msgid "NAVBAR_ITEM_LIGHTS_OFF"
-msgstr "Lights off"
+msgstr "Licht aus"
 
 ## Switch to light mode
 msgid "NAVBAR_ITEM_LIGHTS_ON"
-msgstr "Lights on"
+msgstr "Licht ein"
 
 # Front Page
 
 ## Alt tags, aria labels
 
 msgid "ALT_WEEKLY_TOPIC_BANNER"
-msgstr "Banner advertising the Weekly Topic"
+msgstr "Werbebanner für das Wochenthema"
 
 msgid "ALT_USER_PROFILE_PICTURE"
-msgstr "%s's profile picture"
+msgstr "%s's Profilbild"
 
 msgid "ALT_DRAWN_COMMENT_BY_USER"
-msgstr "Drawn comment by %s"
+msgstr "Gezeichneter Kommentar von %s"
 
 ## Welcome to Sudomemo Box
 
 msgid "WELCOME_BOX_GREET_ADMIN"
-msgstr "Welcome back, %s"
+msgstr "Willkommen zurück, %s"
 
 msgid "WELCOME_BOX_YOU_ARE_ADMIN"
-msgstr "You are logged in as an Administrator."
+msgstr "Du bist als Administrator angemeldet."
 
 msgid "WELCOME_BOX_OPEN_SUDOMIN"
-msgstr "Open Sudomin"
+msgstr "Sudomin öffnen"
 
 ### Our welcome box can change it's greeting, depending on time of day.
 ### It is displayed like this:
 ### Good afternoon, User! Happy Flipnoting!
 
 msgid "WELCOME_BOX_DEFAULT_GREETING"
-msgstr "Hello"
+msgstr "Hallo"
 
 msgid "WELCOME_BOX_MORNING_GREETING"
-msgstr "Good morning"
+msgstr "Guten Morgen"
 
 msgid "WELCOME_BOX_AFTERNOON_GREETING"
-msgstr "Good afternoon"
+msgstr "Guten Nachmittag"
 
 msgid "WELCOME_BOX_EVENING_GREETING"
-msgstr "Good evening"
+msgstr "Guten Abend"
 
 ### "Happy Flipnoting!" is one of our brand catchphrases. "Flipnoting" refers to the act of creating or watching Flipnotes.
 ### Please don't translate "Flipnoting", except to Japanese where you could probably modify the word うごメモ.
 
 msgid "WELCOME_BOX_USERNAME_HAPPY_FLIPNOTING"
-msgstr ", %s! Happy Flipnoting!"
+msgstr ", %s! Frohes Flipnoting!"
 
 msgid "WELCOME_BOX_WELCOME_TO"
-msgstr "Welcome to"
+msgstr "Willkommen zu"
 
 ### Another one of our taglines 
 
 msgid "WELCOME_BOX_SHARE_CREATIVITY_TAGLINE"
-msgstr "Share your creativity with the world!"
+msgstr "Teile deine Kreativität mit der Welt!"
 
 msgid "WELCOME_BOX_WHAT_IS_SUDOMEMO"
-msgstr "Sudomemo is an animation site where people can share flipbook animations - called Flipnotes - created on and posted from the Nintendo DSi and 3DS."
+msgstr "Sudomemo ist eine Animations-Seite, auf welcher Benutzer ihre auf dem Nintendo DSi oder Nintendo 3DS erstellten Daumenkino-Animationen, auch Flipnotes genannt, posten können."
 
 msgid "WELCOME_BOX_HOW_TO_JOIN"
-msgstr "Learn how to Join!"
+msgstr "Erfahre, wie du beitreten kannst!"
 
 # Give, in the same sense as "Donate"
 
 msgid "WELCOME_BOX_GIVE"
-msgstr "Give"
+msgstr "Unterstützen"
 
 ## Flipnote sections
 
 msgid "FLIPNOTE_LIST_RECALCULATING"
-msgstr "The rankings are currently being recalculated. Try reloading the page in a few moments."
+msgstr "Die Rankings werden gerade neu berechnet. Lade die Seite etwas später neu."
 
 msgid "RECENT_FLIPNOTES"
-msgstr "Recent Flipnotes"
+msgstr "Rezente Flipnotes"
 
 msgid "POPULAR_THIS_MONTH"
-msgstr "Popular This Month"
+msgstr "Angesagt diesen Monat"
 
 msgid "HOT_FLIPNOTES"
-msgstr "Hot Flipnotes"
+msgstr "Heiße Flipnotes"
 
 msgid "RANDOM_FLIPNOTES"
-msgstr "Random Flipnotes"
+msgstr "Zufällige Flipnotes"
 
 msgid "FEATURED_FLIPNOTES"
-msgstr "Featured Flipnotes"
+msgstr "Vorgeschlagen Flipnotes"
 
 ## Flipnote by...
 
 msgid "FLIPNOTE_BY_FORMAT"
-msgstr "Flipnote by %s"
+msgstr "Flipnote von %s"
 
 ## Comments section
 
 msgid "VIEWPAGE_COMMENT_WRITE_HERE"
-msgstr "Write here"
+msgstr "Schreibe hier"
 
 msgid "VIEWPAGE_COMMENT_POST_BUTTON"
-msgstr "Post Comment"
+msgstr "Kommentar versenden"
 
 msgid "VIEWPAGE_ADD_MODERATOR_COMMENT"
-msgstr "Add Moderator Comment"
+msgstr "Moderatoren-Kommentar versenden"
 
 msgid "VIEWPAGE_MODERATOR_COMMENT_WARNING"
-msgstr "Do not use this for personal comments."
+msgstr "Nutze diese Funktion nicht zum Versenden persönlicher Kommentare."
 
 ### This is composed of two parts: SIGN_IN and TO_ADD_A_COMMENT
 ### SIGN_IN is a link to the login page, and TO_ADD_A_COMMENT is the part that comes after.
 ### It reads as follows: Sign in to add a comment
 
 msgid "TO_ADD_A_COMMENT"
-msgstr "to add a comment"
+msgstr "um einen Kommentar hinzuzufügen"
 
 ### When the Post Comment button is pressed, it changes to "Posting..." and then "Posted!" when complete.
 msgid "VIEWPAGE_COMMENT_POSTING"
-msgstr "Posting..."
+msgstr "Senden..."
 
 msgid "VIEWPAGE_COMMENT_POSTED"
-msgstr "Posted!"
+msgstr "Erfolgreich versendet!"
 
 ### This can happen in cases of network failure or if the comment is rejected
 msgid "VIEWPAGE_COMMENT_FAILED"
-msgstr "Comment failed..."
+msgstr "Versenden fehlgeschlagen..."
 
 ## Right sidebar
 
@@ -405,210 +404,210 @@ msgid "FRONTPAGE_FLIPNOTE_SPOTLIGHT"
 msgstr "Flipnote Spotlight"
 
 msgid "FRONTPAGE_TRENDING_CREATORS"
-msgstr "Trending Creators"
+msgstr "Angesagte Ersteller"
 
 # Flipnote View Page
 
 msgid "EDIT_FLIPNOTE"
-msgstr "Edit Flipnote"
+msgstr "Flipnote bearbeiten"
 
 msgid "REGION"
 msgstr "Region"
 
 # Comprising the continents of North and South America
 msgid "REGION_AMERICAS"
-msgstr "Americas"
+msgstr "Amerika"
 
 msgid "REGION_EUROPE_AND_OCEANIA"
-msgstr "Europe and Oceania"
+msgstr "Europa and Ozeanien"
 
 msgid "REGION_JAPAN"
 msgstr "Japan"
 
 # Fallback region (this shouldn't happen)
 msgid "REGION_UNKNOWN"
-msgstr "Unknown"
+msgstr "Unbekannt"
 
 msgid "SHARE_ON_FACEBOOK"
-msgstr "Share on Facebook"
+msgstr "Über Facebook teilen"
 
 msgid "SHARE_ON_TWITTER"
-msgstr "Share to Twitter"
+msgstr "Über Twitter teilen"
 
 msgid "SHARE_ON_TUMBLR"
-msgstr "Share on Tumblr"
+msgstr "Über Tumblr teilen"
 
 msgid "SHARE_ON_REDDIT"
-msgstr "Share to Reddit"
+msgstr "Übrr Reddit teilen"
 
 msgid "VIEWPAGE_SPINOFFS"
-msgstr "Spin-offs"
+msgstr "Spin-Offs"
 
 ## MusicMatch
 
 ### Where the Flipnote's audio starts at in the song
 
 msgid "MUSICMATCH_AUDIO_OFFSET"
-msgstr "Starts at %s"
+msgstr "Anfangen bei %s"
 
 msgid "MUSICMATCH_LISTEN_ON_YOUTUBE_MUSIC"
-msgstr "Listen on YouTube Music"
+msgstr "Mit YouTube Music anhören"
 
 msgid "MUSICMATCH_LISTEN_ON_SPOTIFY"
-msgstr "Listen on Spotify"
+msgstr "Mit Spotify anhören"
 
 msgid "MUSICMATCH_ABOUT"
-msgstr "About MusicMatch"
+msgstr "Über MusicMatch"
 
 ## Original Flipnote / Spinoffs
 
 msgid "VIEWPAGE_ORIGINAL_FLIPNOTE"
-msgstr "Original Flipnote"
+msgstr "Originales Flipnote"
 
 msgid "VIEWPAGE_ORIGINAL_FLIPNOTE_NOT_ON_SUDOMEMO"
-msgstr "The original Flipnote isn't on Sudomemo."
+msgstr "Das originale Flipnote ist nicht auf Sudomemo."
 
 # This shows as "by User" underneath the Flipnote thumbnail
 
 msgid "VIEWPAGE_RELATED_FLIPNOTE_BY"
-msgstr "by %s"
+msgstr "von %s"
 
 # Creator's Room (Profile)
 
 msgid "FOLLOWS_YOU"
-msgstr "Follows You"
+msgstr "Folgt dir"
 
 msgid "FOLLOW_BACK"
-msgstr "Follow Back"
+msgstr "Zurück folgen"
 
 msgid "FOLLOWING"
-msgstr "Following"
+msgstr "Folgend"
 
 msgid "FOLLOW"
-msgstr "Follow"
+msgstr "Folgen"
 
 msgid "FOLLOWERS"
-msgstr "Followers"
+msgstr "Follower"
 
 ## はてなID
 msgid "HATENA_ID"
-msgstr "Hatena ID"
+msgstr "Hatena-ID"
 
 msgid "PROFILE_ABOUT_USERNAME"
-msgstr "About %s"
+msgstr "Über %s"
 
 ## User's ★ are from:
 msgid "PROFILE_STAR_COUNTRY_HEADER"
-msgstr "%s's ★s are from:"
+msgstr "%s's ★e stammen aus:"
 
 ## Recent comments on their Flipnotes
 
 msgid "PROFILE_RECENT_COMMENTS"
-msgstr "Recent comments"
+msgstr "Rezente Kommentare"
 
 ## channels that the user posts in most often
 msgid "PROFILE_USER_POSTS_IN"
-msgstr "%s posts in..."
+msgstr "%s postet in..."
 
 # Search page
 
 msgid "SEARCH_SUDOMEMO"
-msgstr "Search Sudomemo"
+msgstr "Sudomemo durchsuchen"
 
 msgid "SEARCH_PAGE_FORM_PLACEHOLDER"
-msgstr "Username, FSID, or channel"
+msgstr "Benutzername, FSID oder Kanal"
 
 msgid "SEARCH_PAGE_FUZZY_SEARCH_TIP"
-msgstr "Tip: You can enter things like 'Austin' and find results like 'ÄuらtÎn'"
+msgstr "Tipp: Mit der Suchanfrage für z.B 'Austin' erhälst du ebenfalls Resultate wie 'ÄuらtÎn'."
 
 msgid "SEARCH_PAGE_NO_RESULTS_FOUND"
-msgstr "No results found."
+msgstr "Keine Resultate gefunden."
 
 msgid "SEARCH_PAGE_TOO_MANY_MATCHED"
-msgstr "Your query matched too many creators - try something more specific."
+msgstr "Deine Angaben stimmten mit zu vielen Nutzern überein. Bitte spezifiziere deine Anfrage."
 
 ## User hasn't posted any Flipnotes yet
 msgid "SEARCH_PAGE_NO_FLIPNOTES_YET"
-msgstr "No Flipnotes yet..."
+msgstr "Noch keine Flipnotes..."
 
 # Edit Flipnote page
 
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
-msgstr "You are editing this Flipnote:"
+msgstr "Du bearbeitest gerade dieses Flipnote:"
 
 msgid "DESCRIPTION_WILL_GO_HERE"
-msgstr "Your description will go here."
+msgstr "Deine Beschreibung gehört hierhin."
 
 msgid "COULD_NOT_SAVE_DETAILS"
-msgstr "Couldn't save details"
+msgstr "Details konnten nicht gespeichert werden"
 
 msgid "PLUS_LEARN_MORE"
-msgstr "Learn more..."
+msgstr "Mehr erfahren..."
 
 msgid "EDIT_PAGE_SUDOMEMO_PLUS_REQUIRED"
-msgstr "You'll need Sudomemo Plus to use these features."
+msgstr "Du benötigst Sudomemo Plus, um diese Features zu benutzen."
 
 # Flipnote smoothing
 msgid "EDIT_PAGE_PLUS_SMOOTHING"
 msgstr "Smoothing"
 
 msgid "EDIT_PAGE_PLUS_AUDIO_ENHANCEMENT"
-msgstr "Audio Enhancement"
+msgstr "Audio-Korrektur"
 
 msgid "EDIT_PAGE_FLIPNOTE_PREVIEW_NOTE"
-msgstr "Note: Flipnote preview does not update."
+msgstr "Anmerkung: Flipnote in Vorschau wird nicht aktualisiert."
 
 msgid "EDIT_PAGE_TITLE_AND_DESCRIPTION"
-msgstr "Title and Description"
+msgstr "Titel & Beschreibung"
 
 msgid "EDIT_PAGE_ENTER_A_TITLE"
-msgstr "Enter a title"
+msgstr "Titel eingeben"
 
 msgid "EDIT_PAGE_ENTER_A_DESCRIPTION"
-msgstr "Enter a description"
+msgstr "Beschreibung eingeben"
 
 msgid "EDIT_PAGE_TITLE_TOOLTIP"
-msgstr "Letters, numbers, and symbols, maximum of 40 characters."
+msgstr "Maximale Charakter-Anzahl: 40"
 
 msgid "EDIT_PAGE_DESCRIPTION_TOOLTIP"
-msgstr "Letters, numbers, and symbols, maximum of 320 characters."
+msgstr "Maximale Charakter-Anzahl: 320"
 
 ## MusicMatch
 
 msgid "EDIT_PAGE_ABOUT_MUSICMATCH_1"
-msgstr "Sudomemo's MusicMatch listens to your Flipnote to find what music it uses!"
+msgstr "Sudomemos MusicMatch hört sich dein Flipnote an und findet den darin benutzten Song!"
 
 msgid "EDIT_PAGE_ABOUT_MUSICMATCH_2"
-msgstr "MusicMatch will sometimes find more than one potential song, or pick the wrong one. If this happens, you can update the displayed song here."
+msgstr "Manchmal findet MusicMatch mehrere potenzielle Resultate, manchmal sind sie sogar falsch. In einem solchen Fall kannst du den angezeigten Song hier ändern."
 
 msgid "EDIT_PAGE_ABOUT_MUSICMATCH_3"
-msgstr "If you update the song, MusicMatch will learn from that information to better detect songs from Flipnote audio in the future."
+msgstr "Bei der Aktualisierung des Songs lernt MusicMatch dazu, um zukünftig genauere Resultate zum Flipnote-Audio erzielen zu können."
 
 msgid "EDIT_PAGE_MUSICMATCH_NO_BGM"
-msgstr "Your Flipnote does not have a background audio track."
+msgstr "Dein Flipnote enthält kein Hintergrundaudio."
 
 msgid "EDIT_PAGE_MUSICMATCH_UNMATCHED"
-msgstr "MusicMatch couldn't find any songs matching your Flipnote."
+msgstr "MusicMatch konnte keinen mit deinem Flipnote übereinstimmenden Song finden."
 
 msgid "EDIT_PAGE_MUSICMATCH_UNMAPPED"
-msgstr "MusicMatch hasn't gotten to your Flipnote yet. Check back again later."
+msgstr "MusicMatch hat dein Flipnote noch nicht geprüft. Versuche es später erneut."
 
 msgid "EDIT_PAGE_MUSICMATCH_PENDING_MAPPING"
-msgstr "MusicMatch is currently processing your Flipnote. Check back again later."
+msgstr "MusicMatch verarbeitet dein Flipnote gerade. Versuche es später erneut."
 
 msgid "EDIT_PAGE_MUSICMATCH_NONE_CORRECT"
-msgstr "None of these are correct"
+msgstr "Keines der Resultate ist korrekt."
 
 msgid "EDIT_PAGE_MUSICMATCH_PREVIEW_ON_YOUTUBE"
-msgstr "Preview on YouTube Music"
+msgstr "Vorschau auf YouTube Music"
 
 msgid "EDIT_PAGE_MUSICMATCH_PREVIEW_ON_SPOTIFY"
-msgstr "Preview on Spotify"
+msgstr "Vorschau auf Spotify"
 
 # Browse Song
 
 msgid "BROWSE_SONG_NO_FLIPNOTES_YET"
-msgstr "There have been no Flipnotes posted with this song yet."
+msgstr "Es wurden noch keine Flipnotes mit diesem Song gepostet."
 
 ## Referring to a music label/publishing company
 msgid "MUSIC_LABEL"
@@ -617,55 +616,54 @@ msgstr "Label"
 # Browse Channel
 
 msgid "BROWSE_CHANNEL_NO_FLIPNOTES_YET"
-msgstr "There have been no Flipnotes posted to this channel yet."
+msgstr "Es wurden noch keine Flipnotes auf diesem Kanal gepostet."
 
 ## Posting permissions
 msgid "CHANNEL_PERM_CLOSED"
-msgstr "Closed"
+msgstr "Geschlossen"
 
 msgid "CHANNEL_PERM_OPEN"
-msgstr "Open"
+msgstr "Offen"
 
 ## categories
 
 msgid "CHANNEL_CAT_NAME_NONE"
-msgstr "None"
+msgstr "Keine"
 
 msgid "CHANNEL_CAT_NAME_ART"
-msgstr "Art"
+msgstr "Zeichnungen"
 
 msgid "CHANNEL_CAT_NAME_GENRES"
 msgstr "Genres"
 
 msgid "CHANNEL_CAT_NAME_TOPICS"
-msgstr "Topics"
+msgstr "Themen"
 
 msgid "CHANNEL_CAT_NAME_ROLEPLAYS"
-msgstr "Roleplays"
+msgstr "Rollenspiele"
 
 msgid "CHANNEL_CAT_NAME_FANDOMS"
-msgstr "Fandoms"
+msgstr "Fan-Gemeinschaften"
 
 msgid "CHANNEL_CAT_NAME_RESOURCES"
-msgstr "Resources"
+msgstr "Ressourcen"
 
 msgid "CHANNEL_CAT_NAME_PERSONAL"
-msgstr "Personal"
+msgstr "Persönliches"
 
 msgid "CHANNEL_CAT_NAME_WEEKLY_TOPIC"
-msgstr "Weekly Topic"
-
+msgstr "Wochen-Thema"
 
 # 404 Page
 
 msgid "404_OOPS_NOT_FOUND"
-msgstr "Oops - That page couldn't be found"
+msgstr "Upps... Die Seite konnte nicht gefunden werden."
 
 msgid "404_WHOOPS_NOT_THERE"
-msgstr "Whoops! Whatever you were looking for, it wasn't there."
+msgstr "Hoppla! Das, wonach du suchst, ist nicht zu finden."
 
 msgid "404_GO_BACK"
-msgstr "Back to Sudomemo Theatre"
+msgstr "Zurück zu Sudomemo Theatre"
 
 # Sudomemo Shop
 
@@ -673,44 +671,44 @@ msgid "TICKETS"
 msgstr "Tickets"
 
 msgid "SUDOMEMO_SHOP_ABOUT_TICKETS_1"
-msgstr "Tickets are fun items on Sudomemo that you can redeem for Stars, Sudomemo Plus, and other things!"
+msgstr "Tickets sind tolle Sudomemo-Items, welche du eintauschen kannst gegen Sterne, Sudomemo Plus und mehr!"
 
 msgid "SUDOMEMO_SHOP_ABOUT_TICKETS_2"
-msgstr "Once you have a ticket, you can redeem it in your Creator's Room by tapping on \"Redeem\" - or, you can give a ticket code as a gift to a friend!"
+msgstr "Wenn du ein Ticket hast, kannst du es in deinem Ersteller-Raum einlösen, indem du \"Einlösen\" antippst. Du kannst es andernfalls an einen Freund weiterverschenken!"
 
 msgid "SUDOMEMO_SHOP_LEARN_ABOUT_PLUS"
-msgstr "Learn about what you can do with Sudomemo Plus:"
+msgstr "Lerne über die Funktionen von Sudomemo Plus:"
 
 msgid "SUDOMEMO_SHOP_ALL_ABOUT_PLUS"
-msgstr "All About Sudomemo Plus"
+msgstr "Alles über Sudomemo Plus"
 
 ## Ticket types..
 
 msgid "TICKET_NAME_one_month_plus_ticket"
-msgstr "Plus Ticket (One Month)"
+msgstr "Plus-Ticket (1 Monat)"
 
 msgid "TICKET_DESC_one_month_plus_ticket"
-msgstr "This ticket will give you one month of Sudomemo Plus!"
+msgstr "Dieses Ticket gewährt dir einen Monat Sudomemo Plus!"
 
 msgid "TICKET_NAME_one_year_plus_ticket"
-msgstr "Plus Ticket (One Year)"
+msgstr "Plus Ticket (1 Jahr)"
 
 msgid "TICKET_DESC_one_year_plus_ticket"
-msgstr "This ticket will give you one year of Sudomemo Plus!"
+msgstr "Dieses Ticket gewährt dir ein Jahr Sudomemo Plus!"
 
 # Login Page
 
 msgid "LOGIN_FAILED_CHECK_DETAILS"
-msgstr "We couldn't log you in. Check the details you entered and try again."
+msgstr "Anmeldung fehlgeschlagen. Überprüfe deine Eingaben und versuche es erneut."
 
 msgid "LOGIN_PLACEHOLDER_USERNAME"
-msgstr "Email or Flipnote Studio ID"
+msgstr "Email der Flipnote-Studio-ID"
 
 msgid "LOGIN_PLACEHOLDER_PASSWORD"
-msgstr "Password"
+msgstr "Passwort"
 
 msgid "LOGIN_SIGNUP_SELECT_DEVICE"
-msgstr "Select your device"
+msgstr "Wähle dein Gerät"
 
 msgid "NINTENDO_DSI"
 msgstr "Nintendo DSi"
@@ -722,4 +720,4 @@ msgstr "Nintendo 3DS"
 
 # See Flipnotes with the song <song name> by <band/artist name>
 msgid "BROWSE_SONG_YOU_ARE_BROWSING_SONG"
-msgstr "See Flipnotes with the song %s by %s"
+msgstr "Flipnotes mit Song %s von %s durchsuchen"

--- a/de_DE/LC_MESSAGES/themeShop.po
+++ b/de_DE/LC_MESSAGES/themeShop.po
@@ -1,20 +1,20 @@
 msgid "THEME_SHOP_LOGIN_REQUIRED"
-msgstr "Du musst eingeloggt sein um den Theme Shop zu benutzen"
+msgstr "Du musst eingeloggt sein, um den Kulissen-Shop zu nutzen."
 
 msgid "THEME_SHOP_MAINPAGE_HEADER"
-msgstr "Hier im Theme Shop kannst du neue Designs für dein Creator's Room kaufen!"
+msgstr "Hier im Kulissen-Shop kannst du neue Kulissen für dein Ersteller-Raum kaufen!"
 
 msgid "THEME_SHOP_LEARN_MORE_HEADER"
-msgstr "Lerne mehr über den Theme Shop"
+msgstr "Lerne mehr über den Kulissen-Shop"
 
 msgid "THEME_SHOP_REPORT_ISSUES_HEADER"
-msgstr "Tippe auf diesen Link um ein Desing zu melden was nicht richtig funktioniert."
+msgstr "Tippe auf diesen Link, um ein fehlerhaftes Design zu melden."
 
 msgid "THEME_SHOP_MAINPAGE_EXCHANGE_COST_FORMAT"
-msgstr "Tauschen für %d Grüne Sterne"
+msgstr "Für %d Grüne Sterne eintauschen"
 
 msgid "THEME_SHOP_MAINPAGE_FREE_STARTER_THEMES"
-msgstr "Kostenlos Starter Designs"
+msgstr "Kostenlose Starter-Kulissen"
 
 msgid "CONGRATULATIONS"
 msgstr "Glückwunsch!"
@@ -29,16 +29,16 @@ msgid "BUY"
 msgstr "Kaufen"
 
 msgid "THEME"
-msgstr "Design"
+msgstr "Kulisse"
 
 msgid "PRICE"
 msgstr "Preis"
 
 msgid "CREATOR"
-msgstr "Creator"
+msgstr "Ersteller"
 
 msgid "DESCRIPTION"
-msgstr "Description"
+msgstr "Beschreibung"
 
 msgid "YOU_HAVE"
 msgstr "Deine Farb-Sterne:"
@@ -53,13 +53,13 @@ msgid "CONFIRM"
 msgstr "Bestätigen"
 
 msgid "CREATORS_ROOM"
-msgstr "Creator's Room"
+msgstr "Ersteller-Raum"
 
 msgid "SHOP_MENU"
-msgstr "Shop Menü"
+msgstr "Shop-Menü"
 
 msgid "NO_DESCRIPTION_AVAILABLE"
-msgstr "No description"
+msgstr "Keine Beschreibung vorhanden"
 
 msgid "THEME_SHOP_SELECT_PAYMENT"
 msgstr "Zahlung auswählen"
@@ -68,28 +68,28 @@ msgid "THEME_SHOP_SELECTED_PAYMENT"
 msgstr "Ausgewählte Zahlung"
 
 msgid "THEME_SHOP_STAR_BALANCE_TOO_LOW"
-msgstr "Sorry, Du hast nicht genug Grüne Sterne für dieses Design."
+msgstr "Du hast nicht genug Grüne Sterne für diese Kulisse. Tut und Leid."
 
 msgid "THEME_SHOP_CHOOSE_CAREFULLY_BEFORE_BUYING"
-msgstr "Alle Käufe sind permanent, also sei vorsichtig beim Kaufen!"
+msgstr "Alle Käufe sind endgültig, also bedenke deine Käufe sorgfältig!"
 
 msgid "THEME_SHOP_YOU_OWN_THIS_THEME"
-msgstr "Dir gehört schon dieses Design."
+msgstr "Dir gehört diese Kulisse schon."
 
 msgid "THEME_SHOP_PUBLIC_THEME"
-msgstr "Jeder Benutzer hat kostenlos zugriff auf dieses Design."
+msgstr "Jeder Benutzer hat kostenlosen Zugriff auf diese Kulisse."
 
 msgid "THEME_SHOP_OWNED_THEME_TRANSACTION_FORMAT"
-msgstr "Du hast das Design auf %s für %d Grüne Sterne."
+msgstr "Du hast die Kulisse am %s für %d Grüne Sterne gekauft."
 
 msgid "THEME_SHOP_CONFIRM_PURCHASE_BELOW"
-msgstr "Bitte bestätige dein Einkauf."
+msgstr "Bitte bestätige deinen Kauf."
 
 msgid "THEME_SHOP_STARS_LEFT_AFTER_PAYMENT"
-msgstr "Nach kauf verfügbare Farb-Sterne:"
+msgstr "Nach Kauf verbleibende Farb-Sterne:"
 
 msgid "THEME_SHOP_POST_PURCHASE"
-msgstr "Dein Einkauf war erfolgreich! Geh zu \"My Themes\"  in deinem Creators room um es auszuwählen!"
+msgstr "Dein Einkauf war erfolgreich! Wähle die Kulisse unter \"Meine Kulissen\" in deinem Ersteller-Raum aus!"
 
 msgid "NAVIGATION_PREVIOUS"
 msgstr "Zurück"
@@ -98,8 +98,8 @@ msgid "NAVIGATION_NEXT"
 msgstr "Weiter"
 
 msgid "THEME_SHOP_SAMPLE_PROFILE"
-msgstr "Profil-Probe"
+msgstr "Profil-Vorschau"
 
 msgid "THEME_SHOP"
-msgstr "Theme Shop"
+msgstr "Kulissenshop"
 

--- a/de_DE/LC_MESSAGES/tickets.po
+++ b/de_DE/LC_MESSAGES/tickets.po
@@ -1,133 +1,131 @@
 # Code Redemption
 
 msgid "REDEEM_CODE"
-msgstr "Redeem Code"
+msgstr "Code einlösen"
 
 msgid "ENTER_CODE_TO_REDEEM"
-msgstr "Enter the code you'd like to redeem below."
+msgstr "Gib den einzulösenden Code hier unten ein."
 
 msgid "CODE_ALREADY_USED"
-msgstr "The code you entered has already been used."
+msgstr "Der eingegebene Code wurde bereits benutzt."
 
 msgid "CODE_INVALID"
-msgstr "The code you entered is invalid."
+msgstr "Der eingegebene Code ist ungültig."
 
 msgid "CODE_NONEXISTING_OR_EXPIRED"
-msgstr "The code you entered doesn't exist or has expired."
+msgstr "Der eingegebene Code existiert entweder nicht oder ist abgelaufen."
 
 msgid "LOGIN_REQUIRED_REDEEM_CODE"
-msgstr "You must be logged in to redeem a code."
+msgstr "Du musst angemelded sein, um einen Code einzulösen."
 
 # Ticket delivery
 
 msgid "YOU_GOT_A_TICKET"
-msgstr "You got a ticket!"
+msgstr "Du hast ein Ticket erhalten!"
 
 msgid "CONTINUE"
-msgstr "Continue"
+msgstr "Weiter"
 
 # Inventory
 
 msgid "INVENTORY"
-msgstr "Inventory"
+msgstr "Inventar"
 
 msgid "USE_ITEM"
-msgstr "Use"
+msgstr "Benutzen"
 
 msgid "INVENTORY_IS_EMPTY"
-msgstr "Your inventory is empty."
+msgstr "Dein Inventar ist leer."
 
 # Ticket redemption
 
 msgid "TICKET_REDEEM_WIN_FORMAT"
-msgstr "You redeemed the %s!"
+msgstr "%s wurde eingelöst!"
 
 msgid "TICKET_REDEEM_LOSE_FORMAT"
-msgstr "You redeemed the %s, but..."
+msgstr "%s wurde eingelöst, aber..."
 
 msgid "TICKET_REDEEM_NO_PRIZES"
-msgstr "You didn't win anything. Sorry!"
+msgstr "Du hast nichts gewonnen. Schade!"
 
 msgid "COLOR_STARS"
-msgstr "Color Stars"
+msgstr "Farbene Sterne"
 
 msgid "CREATORS_ROOM_THEME"
-msgstr "Creator's Room Theme"
+msgstr "Ersteller-Raum-Kulisse"
 
 msgid "SUDOMEMO_CITIZENSHIP"
-msgstr "Sudomemo Citizenship"
+msgstr "Sudomemo-Bürgerschaft"
 
 msgid "THEME_AVAILABLE_FOR_USE"
-msgstr "You can now use this theme in your Creator's Room!"
+msgstr "Du kannst diese Kulisse nun in deinem Ersteller-Raum anwenden!"
 
 msgid "SUDOMEMO_PLUS"
 msgstr "Sudomemo Plus"
 
 msgid "SUDOMEMO_PLUS_FORMAT"
-msgstr "You received %s days worth of Sudomemo Plus!"
+msgstr "Du hast %s Tage Sudomemo Plus erhalten!"
 
 msgid "SUDOMEMO_PLUS_BALANCE_FORMAT"
-msgstr "Balance: %s days"
+msgstr "Kontostand: %s Tage"
 
 # Each ticket type will have a name and a description 
 
 msgid "TICKET_NAME_demo_ticket"
-msgstr "Demo Ticket"
+msgstr "Demo-Ticket"
 
 msgid "TICKET_DESC_demo_ticket"
-msgstr "Obviously, this is the description for the demo ticket."
+msgstr "Dies ist tatsächlich die Beschreibung des Demo-Tickets."
 
 msgid "TICKET_NAME_regular_ticket"
-msgstr "Regular Ticket"
+msgstr "Normales Ticket"
 
 msgid "TICKET_DESC_regular_ticket"
-msgstr "Thank you for using Sudomemo!"
+msgstr "Vielen Dank, dass du Sudomemo nutzt!"
 
 msgid "TICKET_NAME_twitter_promo_ticket"
-msgstr "Twitter Promo Ticket"
+msgstr "Twitter-Promo-Ticket"
 
 msgid "TICKET_DESC_twitter_promo_ticket"
-msgstr "Thanks for following the Sudomemo Twitter!"
+msgstr "Vielen Dank, dass du Sudomemo auf Twitter folgst!"
 
 msgid "TICKET_NAME_instagram_promo_ticket"
-msgstr "Instagram Promo Ticket"
+msgstr "Instagram-Promo-Ticket"
 
 msgid "TICKET_DESC_instagram_promo_ticket"
-msgstr "Thanks for following the Sudomemo Instagram!"
+msgstr "Vielen Dank, dass du Sudomemo auf Instagram folgst!"
 
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
-msgstr "Weekly Topic Winner Ticket"
+msgstr "Woche-Gewinner-Ticket"
 
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
-msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
+msgstr "Glückwunsch zum Gewinn des Wochen-Themas auf Sudomemo!"
 
 msgid "TICKET_NAME_birthday_ticket"
-msgstr "Birthday Ticket"
+msgstr "Geburtstags-Ticket"
 
 msgid "TICKET_DESC_birthday_ticket"
-msgstr "Happy Birthday!"
+msgstr "Alles Gute!"
 
 msgid "TICKET_NAME_love_anniversary_ticket"
-msgstr "Anniversary Ticket"
+msgstr "Jubiläums-Ticket"
 
 # The last character of this message is the DSi symbol for a heart. Don't remove it.
 msgid "TICKET_DESC_love_anniversary_ticket" 
-msgstr "Happy Anniversary "
+msgstr "Alles Gute zum Jubiläum! "
 
 # Sudomemo Plus
 msgid "TICKET_NAME_one_month_plus_ticket"
-msgstr "Plus Ticket (One Month)"
+msgstr "Plus-Ticket (1 Monat)"
 
 msgid "TICKET_DESC_one_month_plus_ticket"
-msgstr "This ticket will give you one month of Sudomemo Plus!"
+msgstr "Dieses Ticket gewährt dir einen Monat Sudomemo Plus!"
 
 msgid "TICKET_NAME_one_year_plus_ticket"
-msgstr "Plus Ticket (One Year)"
+msgstr "Plus-Ticket (1 Jahr)"
 
 msgid "TICKET_DESC_one_year_plus_ticket"
-msgstr "This ticket will give you one year of Sudomemo Plus!"
-
+msgstr "Dieses Ticket gewährt dir ein Jahr Sudomemo Plus!"
 
 msgid "DONT_HAVE_ANY_TO_USE"
-msgstr "You don't have any of that item to use."
-
+msgstr "Du hast kein Item, welches du nutzen könntest."

--- a/de_DE/LC_MESSAGES/unreadComments.po
+++ b/de_DE/LC_MESSAGES/unreadComments.po
@@ -1,19 +1,17 @@
 msgid "LOGIN_REQUIRED_TO_VIEW_PAGE"
-msgstr "You must log in to view this page."
+msgstr "Du musst angemeldet sein, um diese Seite zu sehen."
 
 msgid "HEADER_UNREAD_COMMENTS"
-msgstr "Unread Comments"
+msgstr "Ungelesene Kommentare"
 
 msgid "NO_UNREAD_COMMENTS"
-msgstr "You have no unread comments."
+msgstr "Du hast keine ungelesenen Kommentare."
 
 msgid "TAP_ON_FLIPNOTE_ID_TO_VISIT_COMMENTS"
-msgstr "Tap on a Flipnote ID to visit the comments page."
+msgstr "Tippe auf eine Flipnote-ID, um die Kommentare zu sehen."
 
 msgid "FLIPNOTE_ID"
-msgstr "Flipnote ID"
+msgstr "Flipnote-ID"
 
 msgid "UNREAD"
-msgstr "Unread"
-
-
+msgstr "Ungelesen"

--- a/de_DE/LC_MESSAGES/unreadCommentsEmail.po
+++ b/de_DE/LC_MESSAGES/unreadCommentsEmail.po
@@ -1,20 +1,20 @@
 msgid "EMAIL_SUBJECT_FORMAT"
-msgstr "[Sudomemo] %s, you've got new comments on your Flipnotes!"
+msgstr "[Sudomemo] %s, du hast neue Kommentare auf deinen Flipnotes!"
 
 msgid "TITLE_NEW_COMMENTS"
-msgstr "New Comments"
+msgstr "Neue Kommentare"
 
 msgid "HELLO_FORMAT"
-msgstr "Hello, %s!"
+msgstr "Hallo, %s!"
 
 msgid "TEXT_YOU_HAVE_X_COMMENTS_FROM_FORMAT"
-msgstr "You have %d new comment(s) on Sudomemo from %s"
+msgstr "Du hast %d neue(n) Kommentar(e) von %s auf Sudomemo"
 
 msgid "AND"
-msgstr "and"
+msgstr "und"
 
 msgid "AND_X_OTHERS_FORMAT"
-msgstr "and %s others."
+msgstr "und %s Anderen."
 
 msgid "TEXT_HOW_TO_VIEW_UNREAD_COMMENTS_TAP_ICON_FORMAT"
-msgstr "You can view your unread comments on Sudomemo by tapping %s on your notification bar."
+msgstr "Du kannst die ungelesenen Kommentare auf Sudomemo einsehen, indem du auf %s in deiner Benachrichtigunsleiste tippst."

--- a/de_DE/LC_MESSAGES/userMovieList.po
+++ b/de_DE/LC_MESSAGES/userMovieList.po
@@ -17,7 +17,7 @@ msgid "FLIPNOTES_BY_FORMAT"
 msgstr "Flipnotes von %s"
 
 msgid "STARRED_BY_FORMAT"
-msgstr "Angeschaut von %s"
+msgstr "Sterne gegeben von %s"
 
 msgid "FAVORITES_FEED_FORMAT"
-msgstr "%s's Feed den er am liebsten mag"
+msgstr "%s's Favoriten-Feed"


### PR DESCRIPTION
A complete overhaul of the German translation of Sudomemo.

- grammatical errors fixed;
- more suitable vocabulary and phrasing used;
- all missing translations are completed, including that of the newly added theatre.po file;
- similar messages are a bit more uniform;
- since the German language likes to elongate words by attaching one or more words to another (ironic example: 'Wort|neu|schöpfung'), hyphens were added for better readability
- other compulsory hyphens added;
- translations for the retired service Sudomemo Citizenship were added for legacy purposes