### PR TITLE
added Japanese theatre.po

### DIFF
--- a/ja_JP/LC_MESSAGES/theatre.po
+++ b/ja_JP/LC_MESSAGES/theatre.po
@@ -2,34 +2,34 @@
 
 # Meta tags, descriptions, etc
 msgid "SUDOMEMO"
-msgstr "Sudomemo"
+msgstr "スドメモ"
 
 msgid "SUDOMEMO_THEATRE"
-msgstr "Sudomemo Theatre"
+msgstr "スドメモシアター"
 
 msgid "SUDOMEMO_NEWS"
-msgstr "Sudomemo News"
+msgstr "スドメモニュース"
 
 msgid "SUDOMEMO_SHOP"
-msgstr "Sudomemo Shop"
+msgstr "スドメモショップ"
 
 msgid "SUDOMEMO_SHOP_META_DESCRIPTION"
-msgstr "Sudomemo Shop: Sudomemo merch, tickets for Plus and Stars, and other fun things!"
+msgstr "スドメモショップ：スドメモプラスのチケットやスター、その他の追加コンテンツを購入できます！"
 
 msgid "DEFAULT_META_DESCRIPTION"
-msgstr "Sudomemo: Share your Flipnotes with the world! For Nintendo DSi and 3DS."
+msgstr "スドメモ：作ったメモを世界に発信しよう！DSiと3DSに対応。"
 
 msgid "FRONTPAGE_TITLE_TAGLINE"
-msgstr "Sudomemo: Flipnote Hatena is back!"
+msgstr "スドメモ：うごメモはてなを再び！"
 
 msgid "VIEWPAGE_COMMENT_TEXTBOX"
-msgstr "Comment entry text box"
+msgstr "コメントを入力"
 
 ## "Username - 3 fans, 25 Flipnotes on Sudomemo"
 ## Not going to bother making plural variants
 
 msgid "PROFILE_DEFAULT_DESCRIPTION"
-msgstr "%s - %s fans, %s Flipnotes on Sudomemo"
+msgstr "%s - %sファン、%s作品 on スドメモ"
 
 # Date-time formats
 # You can adjust the way dates display to match your region better.
@@ -40,204 +40,204 @@ msgstr "%s - %s fans, %s Flipnotes on Sudomemo"
 # Wednesday, December 3rd, 2019
 # Used for news articles
 msgid "DATETIME_WEEKDAY_MONTH_DAY_ORDINAL_YEAR_FORMAT"
-msgstr "l, F jS, Y"
+msgstr "Y/m/d D"
 
 # November 29th, 2019 08:23:07
 # Used for Flipnote Details
 msgid "DATETIME_MONTH_DAY_ORDINAL_HOUR_MINUTE_SECOND_FORMAT"
-msgstr "F jS, Y h:i:s"
+msgstr "Y/m/d h:i:s"
 
 # Very common terms and one-word translations
 
 msgid "ARTIST"
-msgstr "Artist"
+msgstr "アーティスト"
 
 # Back, in the sense of navigation
 msgid "BACK"
-msgstr "Back"
+msgstr "戻る"
 
 msgid "CATEGORY"
-msgstr "Category"
+msgstr "カテゴリー"
 
 msgid "CHANNEL"
-msgstr "Channel"
+msgstr "チャンネル"
 
 msgid "CHANNELS"
-msgstr "Channels"
+msgstr "チャンネル"
 
 msgid "COMMENTS"
-msgstr "Comments"
+msgstr "コメント"
 
 msgid "CREATOR"
-msgstr "Creator"
+msgstr "作者"
 
 msgid "CREATORS"
-msgstr "Creators"
+msgstr "作者"
 
 msgid "CREATORS_ROOM"
-msgstr "Creator's Room"
+msgstr "マイルーム"
 
 msgid "DETAILS"
-msgstr "Details"
+msgstr "詳細"
 
 msgid "DESCRIPTION"
-msgstr "Description"
+msgstr "説明"
 
 msgid "DOWNLOADS"
-msgstr "Downloads"
+msgstr "ダウンロード"
 
 msgid "FANS"
-msgstr "Fans"
+msgstr "ファン"
 
 msgid "FEATURED"
-msgstr "Featured"
+msgstr "特集"
 
 msgid "FLIPNOTE_ID"
-msgstr "Flipnote ID"
+msgstr "作品ID"
 
 msgid "FLIPNOTE"
-msgstr "Flipnote"
+msgstr "うごメモ"
 
 msgid "FLIPNOTES"
-msgstr "Flipnotes"
+msgstr "うごメモ"
 
 # This is short for Flipnote Studio ID. Leave it as "FSID" except in Japanese, where it should be うごメモID
 msgid "FSID"
-msgstr "FSID"
+msgstr "うごメモID"
 
 # Japanese translation should also be be うごメモID here
 msgid "FLIPNOTE_STUDIO_ID"
-msgstr "Flipnote Studio ID"
+msgstr "うごメモID"
 
 msgid "GENRE"
-msgstr "Genre"
+msgstr "ジャンル"
 
 msgid "HELP_CENTER"
-msgstr "Help Center"
+msgstr "ヘルプセンター"
 
 msgid "HOT"
-msgstr "Hot"
+msgstr "流行作品"
 
 msgid "INFO"
-msgstr "Info"
+msgstr "情報"
 
 msgid "LATEST"
-msgstr "Latest"
+msgstr "新着作品"
 
 msgid "MODERATOR"
-msgstr "Moderator"
+msgstr "運営"
 
 msgid "MORE"
-msgstr "More"
+msgstr "もっと見る"
 
 msgid "MUSICMATCH"
 msgstr "MusicMatch"
 
 msgid "NEXT"
-msgstr "Next"
+msgstr "次へ"
 
 msgid "NEWS"
-msgstr "News"
+msgstr "ニュース"
 
 # Channel permissions: Is posting Flipnotes to a channel allowed or not?
 msgid "PERMISSIONS"
-msgstr "Permissions"
+msgstr "同意する"
 
 msgid "POPULAR"
-msgstr "Popular"
+msgstr "人気作品"
 
 # Previous, abbreviated "Prev". Should be a maximum of 4 characters.
 msgid "PREV"
-msgstr "Prev"
+msgstr "前へ"
 
 msgid "RANDOM"
-msgstr "Random"
+msgstr "ランダム"
 
 # Referring to a release date/publishing date
 msgid "RELEASED"
-msgstr "Released"
+msgstr "新着順"
 
 msgid "RANK"
-msgstr "Rank"
+msgstr "順位"
 
 msgid "RECENT"
-msgstr "Recent"
+msgstr "新着順"
 
 msgid "SAVE"
-msgstr "Save"
+msgstr "保存"
 
 msgid "SAVING"
-msgstr "Saving"
+msgstr "保存中"
 
 msgid "SEARCH"
-msgstr "Search"
+msgstr "検索"
 
 msgid "SHARE"
-msgstr "Share"
+msgstr "共有"
 
 msgid "SIGN_UP"
-msgstr "Sign Up"
+msgstr "新規登録"
 
 msgid "SIGN_IN"
-msgstr "Sign in"
+msgstr "サインイン"
 
 msgid "SIGN_OUT"
-msgstr "Sign out"
+msgstr "サインアウト"
 
 msgid "STARS"
-msgstr "Stars"
+msgstr "スター"
 
 msgid "TITLE"
-msgstr "Title"
+msgstr "タイトル"
 
 
 # Referring to being the most popular (in terms of ranking)
 msgid "TOP"
-msgstr "Top"
+msgstr "トップ"
 
 # Number of times something has been viewed, or played.
 msgid "VIEWS"
-msgstr "Views"
+msgstr "えつらん回数"
 
 # For MusicMatch
 
 msgid "SONG"
-msgstr "Song"
+msgstr "楽曲"
 
 msgid "SUDOMEMO_PLUS"
-msgstr "Sudomemo Plus"
+msgstr "スドメモプラス"
 
 # Navbar
 
 msgid "NAVBAR_TOGGLE_NAVIGATION"
-msgstr "Toggle navigation"
+msgstr "ナビゲーションの切り替え"
 
 msgid "NAVBAR_ITEM_SHOP"
-msgstr "Shop"
+msgstr "ショップ"
 
 msgid "NAVBAR_ITEM_HELP"
-msgstr "Help"
+msgstr "ヘルプ"
 
 msgid "NAVBAR_ITEM_USEFUL_LINKS"
-msgstr "Useful Links"
+msgstr "お役立ちリンク"
 
 msgid "NAVBAR_ITEM_DISCORD"
 msgstr "Discord"
 
 msgid "NAVBAR_ITEM_HOW_TO_JOIN"
-msgstr "How to Join"
+msgstr "接続方法"
 
 msgid "NAVBAR_ITEM_CONNECTION_HELP"
-msgstr "Connection Help"
+msgstr "接続ヘルプ"
 
 msgid "NAVBAR_ITEM_FAQS"
-msgstr "FAQs"
+msgstr "FAQ"
 
 msgid "NAVBAR_ITEM_TERMS"
-msgstr "Terms of Use"
+msgstr "利用規約"
 
 msgid "NAVBAR_ITEM_CONTACT_US"
-msgstr "Contact Us"
+msgstr "お問い合わせ"
 
 msgid "NAVBAR_ITEM_TWITTER"
 msgstr "Twitter"
@@ -252,10 +252,10 @@ msgid "NAVBAR_ITEM_EMAIL"
 msgstr "Email"
 
 msgid "NAVBAR_ITEM_OTHER"
-msgstr "Other"
+msgstr "その他"
 
 msgid "NAVBAR_ITEM_CREDITS"
-msgstr "Credits"
+msgstr "クレジット"
 
 msgid "NAVBAR_ITEM_ADMIN"
 msgstr "Admin"
@@ -264,209 +264,209 @@ msgid "NAVBAR_ITEM_SUDOMEMO_ADMIN"
 msgstr "Sudomin"
 
 msgid "NAVBAR_ITEM_REPORTED_FLIPNOTES"
-msgstr "Reported Flipnotes"
+msgstr "規約違反を通報"
 
 msgid "NAVBAR_ITEM_SWITCH_TO_USER_ACCOUNT"
-msgstr "Switch to user account"
+msgstr "アカウントを切り替える"
 
 ## Switch to dark mode
 msgid "NAVBAR_ITEM_LIGHTS_OFF"
-msgstr "Lights off"
+msgstr "ダークモード"
 
 ## Switch to light mode
 msgid "NAVBAR_ITEM_LIGHTS_ON"
-msgstr "Lights on"
+msgstr "ライトモード"
 
 # Front Page
 
 ## Alt tags, aria labels
 
 msgid "ALT_WEEKLY_TOPIC_BANNER"
-msgstr "Banner advertising the Weekly Topic"
+msgstr "「今週のお題」宣伝バナー"
 
 msgid "ALT_USER_PROFILE_PICTURE"
-msgstr "%s's profile picture"
+msgstr "%sさんのプロフィール画像"
 
 msgid "ALT_DRAWN_COMMENT_BY_USER"
-msgstr "Drawn comment by %s"
+msgstr "%sさんのコメント"
 
 ## Welcome to Sudomemo Box
 
 msgid "WELCOME_BOX_GREET_ADMIN"
-msgstr "Welcome back, %s"
+msgstr "お疲れ様です、%sさん"
 
 msgid "WELCOME_BOX_YOU_ARE_ADMIN"
-msgstr "You are logged in as an Administrator."
+msgstr "管理者権限でログインしています。"
 
 msgid "WELCOME_BOX_OPEN_SUDOMIN"
-msgstr "Open Sudomin"
+msgstr "Sudominを開く"
 
 ### Our welcome box can change it's greeting, depending on time of day.
 ### It is displayed like this:
 ### Good afternoon, User! Happy Flipnoting!
 
 msgid "WELCOME_BOX_DEFAULT_GREETING"
-msgstr "Hello"
+msgstr "こんにちは"
 
 msgid "WELCOME_BOX_MORNING_GREETING"
-msgstr "Good morning"
+msgstr "おはよう"
 
 msgid "WELCOME_BOX_AFTERNOON_GREETING"
-msgstr "Good afternoon"
+msgstr "こんにちは"
 
 msgid "WELCOME_BOX_EVENING_GREETING"
-msgstr "Good evening"
+msgstr "こんばんは"
 
 ### "Happy Flipnoting!" is one of our brand catchphrases. "Flipnoting" refers to the act of creating or watching Flipnotes.
 ### Please don't translate "Flipnoting", except to Japanese where you could probably modify the word うごメモ.
 
 msgid "WELCOME_BOX_USERNAME_HAPPY_FLIPNOTING"
-msgstr ", %s! Happy Flipnoting!"
+msgstr "、%s！ Happy Flipnoting！"
 
 msgid "WELCOME_BOX_WELCOME_TO"
-msgstr "Welcome to"
+msgstr "ようこそ"
 
 ### Another one of our taglines 
 
 msgid "WELCOME_BOX_SHARE_CREATIVITY_TAGLINE"
-msgstr "Share your creativity with the world!"
+msgstr "作ったメモを世界に発信しよう！"
 
 msgid "WELCOME_BOX_WHAT_IS_SUDOMEMO"
-msgstr "Sudomemo is an animation site where people can share flipbook animations - called Flipnotes - created on and posted from the Nintendo DSi and 3DS."
+msgstr "スドメモはNintendo DSiと3DSで作成したメモ帳のアニメーション、「うごメモ」を投稿して共有できるアニメーションサイトです。"
 
 msgid "WELCOME_BOX_HOW_TO_JOIN"
-msgstr "Learn how to Join!"
+msgstr "接続方法はこちら！"
 
 # Give, in the same sense as "Donate"
 
 msgid "WELCOME_BOX_GIVE"
-msgstr "Give"
+msgstr "援助"
 
 ## Flipnote sections
 
 msgid "FLIPNOTE_LIST_RECALCULATING"
-msgstr "The rankings are currently being recalculated. Try reloading the page in a few moments."
+msgstr "現在ランキングの集計中です。しばらく待ってから再度読み込んでください。"
 
 msgid "RECENT_FLIPNOTES"
-msgstr "Recent Flipnotes"
+msgstr "新着作品"
 
 msgid "POPULAR_THIS_MONTH"
-msgstr "Popular This Month"
+msgstr "今月の人気作品"
 
 msgid "HOT_FLIPNOTES"
-msgstr "Hot Flipnotes"
+msgstr "流行作品"
 
 msgid "RANDOM_FLIPNOTES"
-msgstr "Random Flipnotes"
+msgstr "ランダム"
 
 msgid "FEATURED_FLIPNOTES"
-msgstr "Featured Flipnotes"
+msgstr "おすすめ作品"
 
 ## Flipnote by...
 
 msgid "FLIPNOTE_BY_FORMAT"
-msgstr "Flipnote by %s"
+msgstr "%sさんの作品"
 
 ## Comments section
 
 msgid "VIEWPAGE_COMMENT_WRITE_HERE"
-msgstr "Write here"
+msgstr "ここに入力してください"
 
 msgid "VIEWPAGE_COMMENT_POST_BUTTON"
-msgstr "Post Comment"
+msgstr "コメントを送信"
 
 msgid "VIEWPAGE_ADD_MODERATOR_COMMENT"
-msgstr "Add Moderator Comment"
+msgstr "運営コメントを送信"
 
 msgid "VIEWPAGE_MODERATOR_COMMENT_WARNING"
-msgstr "Do not use this for personal comments."
+msgstr "個人的なコメントは送信しないでください"
 
 ### This is composed of two parts: SIGN_IN and TO_ADD_A_COMMENT
 ### SIGN_IN is a link to the login page, and TO_ADD_A_COMMENT is the part that comes after.
 ### It reads as follows: Sign in to add a comment
 
 msgid "TO_ADD_A_COMMENT"
-msgstr "to add a comment"
+msgstr "コメントを送信"
 
 ### When the Post Comment button is pressed, it changes to "Posting..." and then "Posted!" when complete.
 msgid "VIEWPAGE_COMMENT_POSTING"
-msgstr "Posting..."
+msgstr "送信中…"
 
 msgid "VIEWPAGE_COMMENT_POSTED"
-msgstr "Posted!"
+msgstr "送信しました！"
 
 ### This can happen in cases of network failure or if the comment is rejected
 msgid "VIEWPAGE_COMMENT_FAILED"
-msgstr "Comment failed..."
+msgstr "コメントの送信に失敗しました…"
 
 ## Right sidebar
 
 msgid "FRONTPAGE_FLIPNOTE_SPOTLIGHT"
-msgstr "Flipnote Spotlight"
+msgstr "注目作品"
 
 msgid "FRONTPAGE_TRENDING_CREATORS"
-msgstr "Trending Creators"
+msgstr "注目作者"
 
 # Flipnote View Page
 
 msgid "EDIT_FLIPNOTE"
-msgstr "Edit Flipnote"
+msgstr "編集"
 
 msgid "REGION"
-msgstr "Region"
+msgstr "地域"
 
 # Comprising the continents of North and South America
 msgid "REGION_AMERICAS"
-msgstr "Americas"
+msgstr "アメリカ"
 
 msgid "REGION_EUROPE_AND_OCEANIA"
-msgstr "Europe and Oceania"
+msgstr "欧州・オセアニア"
 
 msgid "REGION_JAPAN"
-msgstr "Japan"
+msgstr "日本"
 
 # Fallback region (this shouldn't happen)
 msgid "REGION_UNKNOWN"
-msgstr "Unknown"
+msgstr "不明"
 
 msgid "SHARE_ON_FACEBOOK"
-msgstr "Share on Facebook"
+msgstr "Facebookで共有"
 
 msgid "SHARE_ON_TWITTER"
-msgstr "Share to Twitter"
+msgstr "Twitterで共有"
 
 msgid "SHARE_ON_TUMBLR"
-msgstr "Share on Tumblr"
+msgstr "Tumblrで共有"
 
 msgid "SHARE_ON_REDDIT"
-msgstr "Share to Reddit"
+msgstr "Redditで共有"
 
 msgid "VIEWPAGE_SPINOFFS"
-msgstr "Spin-offs"
+msgstr "子作品"
 
 ## MusicMatch
 
 ### Where the Flipnote's audio starts at in the song
 
 msgid "MUSICMATCH_AUDIO_OFFSET"
-msgstr "Starts at %s"
+msgstr "%s~"
 
 msgid "MUSICMATCH_LISTEN_ON_YOUTUBE_MUSIC"
-msgstr "Listen on YouTube Music"
+msgstr "YouTube Musicで聴く"
 
 msgid "MUSICMATCH_LISTEN_ON_SPOTIFY"
-msgstr "Listen on Spotify"
+msgstr "Spotifyで聴く"
 
 msgid "MUSICMATCH_ABOUT"
-msgstr "About MusicMatch"
+msgstr "MusicMatchについて"
 
 ## Original Flipnote / Spinoffs
 
 msgid "VIEWPAGE_ORIGINAL_FLIPNOTE"
-msgstr "Original Flipnote"
+msgstr "親作品"
 
 msgid "VIEWPAGE_ORIGINAL_FLIPNOTE_NOT_ON_SUDOMEMO"
-msgstr "The original Flipnote isn't on Sudomemo."
+msgstr "親作品が見つかりませんでした。"
 
 # This shows as "by User" underneath the Flipnote thumbnail
 
@@ -476,241 +476,241 @@ msgstr "by %s"
 # Creator's Room (Profile)
 
 msgid "FOLLOWS_YOU"
-msgstr "Follows You"
+msgstr "あなたのファンです"
 
 msgid "FOLLOW_BACK"
-msgstr "Follow Back"
+msgstr "お気に入りに登録"
 
 msgid "FOLLOWING"
-msgstr "Following"
+msgstr "お気に入り"
 
 msgid "FOLLOW"
-msgstr "Follow"
+msgstr "お気に入りに追加"
 
 msgid "FOLLOWERS"
-msgstr "Followers"
+msgstr "ファン"
 
 ## はてなID
 msgid "HATENA_ID"
-msgstr "Hatena ID"
+msgstr "はてなID"
 
 msgid "PROFILE_ABOUT_USERNAME"
-msgstr "About %s"
+msgstr "%sさんのプロフィール"
 
 ## User's ★ are from:
 msgid "PROFILE_STAR_COUNTRY_HEADER"
-msgstr "%s's ★s are from:"
+msgstr "★をもらった国"
 
 ## Recent comments on their Flipnotes
 
 msgid "PROFILE_RECENT_COMMENTS"
-msgstr "Recent comments"
+msgstr "最近ついたコメント"
 
 ## channels that the user posts in most often
 msgid "PROFILE_USER_POSTS_IN"
-msgstr "%s posts in..."
+msgstr "%sさんが投稿したチャンネル"
 
 # Search page
 
 msgid "SEARCH_SUDOMEMO"
-msgstr "Search Sudomemo"
+msgstr "検索"
 
 msgid "SEARCH_PAGE_FORM_PLACEHOLDER"
-msgstr "Username, FSID, or channel"
+msgstr "ユーザー名、うごメモIDまたはチャンネル名を入力"
 
 msgid "SEARCH_PAGE_FUZZY_SEARCH_TIP"
-msgstr "Tip: You can enter things like 'Austin' and find results like 'ÄuらtÎn'"
+msgstr "ヒント：例えば「ÄuらtÎn」を探す場合には「Austin」と入力しても見つけることができます"
 
 msgid "SEARCH_PAGE_NO_RESULTS_FOUND"
-msgstr "No results found."
+msgstr "見つかりませんでした。"
 
 msgid "SEARCH_PAGE_TOO_MANY_MATCHED"
-msgstr "Your query matched too many creators - try something more specific."
+msgstr "検索結果が多すぎます。キーワードを増やして試してください。"
 
 ## User hasn't posted any Flipnotes yet
 msgid "SEARCH_PAGE_NO_FLIPNOTES_YET"
-msgstr "No Flipnotes yet..."
+msgstr "まだ作品を投稿していません"
 
 # Edit Flipnote page
 
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
-msgstr "You are editing this Flipnote:"
+msgstr "編集中のうごメモ："
 
 msgid "DESCRIPTION_WILL_GO_HERE"
-msgstr "Your description will go here."
+msgstr "説明文はここに表示されます。"
 
 msgid "COULD_NOT_SAVE_DETAILS"
-msgstr "Couldn't save details"
+msgstr "詳細を保存できませんでした。"
 
 msgid "PLUS_LEARN_MORE"
-msgstr "Learn more..."
+msgstr "詳しくはこちら"
 
 msgid "EDIT_PAGE_SUDOMEMO_PLUS_REQUIRED"
-msgstr "You'll need Sudomemo Plus to use these features."
+msgstr "この機能を利用するにはスドメモプラスを手に入れる必要があります。"
 
 # Flipnote smoothing
 msgid "EDIT_PAGE_PLUS_SMOOTHING"
-msgstr "Smoothing"
+msgstr "画質の最適化"
 
 msgid "EDIT_PAGE_PLUS_AUDIO_ENHANCEMENT"
-msgstr "Audio Enhancement"
+msgstr "音質向上"
 
 msgid "EDIT_PAGE_FLIPNOTE_PREVIEW_NOTE"
-msgstr "Note: Flipnote preview does not update."
+msgstr "注意：うごメモのプレビューは更新されません。"
 
 msgid "EDIT_PAGE_TITLE_AND_DESCRIPTION"
-msgstr "Title and Description"
+msgstr "タイトルと説明文"
 
 msgid "EDIT_PAGE_ENTER_A_TITLE"
-msgstr "Enter a title"
+msgstr "タイトルを入力"
 
 msgid "EDIT_PAGE_ENTER_A_DESCRIPTION"
-msgstr "Enter a description"
+msgstr "説明文を入力"
 
 msgid "EDIT_PAGE_TITLE_TOOLTIP"
-msgstr "Letters, numbers, and symbols, maximum of 40 characters."
+msgstr "文字、数字、記号を40字まで使用できます。"
 
 msgid "EDIT_PAGE_DESCRIPTION_TOOLTIP"
-msgstr "Letters, numbers, and symbols, maximum of 320 characters."
+msgstr "文字、数字、記号を320文字まで使用できます。"
 
 ## MusicMatch
 
 msgid "EDIT_PAGE_ABOUT_MUSICMATCH_1"
-msgstr "Sudomemo's MusicMatch listens to your Flipnote to find what music it uses!"
+msgstr "スドメモMusicMatchは作品に使用された楽曲を自動で識別します！"
 
 msgid "EDIT_PAGE_ABOUT_MUSICMATCH_2"
-msgstr "MusicMatch will sometimes find more than one potential song, or pick the wrong one. If this happens, you can update the displayed song here."
+msgstr "MusicMatchは誤った曲や複数の関係のない曲を表示する場合があります。その際は表示される曲名をここで修正することができます。"
 
 msgid "EDIT_PAGE_ABOUT_MUSICMATCH_3"
-msgstr "If you update the song, MusicMatch will learn from that information to better detect songs from Flipnote audio in the future."
+msgstr "修正した曲情報は、うごメモから音源を検出するMusicMatchの精度向上にも活用されます"
 
 msgid "EDIT_PAGE_MUSICMATCH_NO_BGM"
-msgstr "Your Flipnote does not have a background audio track."
+msgstr "この作品にはBGMがありません。"
 
 msgid "EDIT_PAGE_MUSICMATCH_UNMATCHED"
-msgstr "MusicMatch couldn't find any songs matching your Flipnote."
+msgstr "この作品に使用された楽曲は見つかりませんでした。"
 
 msgid "EDIT_PAGE_MUSICMATCH_UNMAPPED"
-msgstr "MusicMatch hasn't gotten to your Flipnote yet. Check back again later."
+msgst "MusicMatchの処理を開始します。時間をおいて確認してください。"
 
 msgid "EDIT_PAGE_MUSICMATCH_PENDING_MAPPING"
-msgstr "MusicMatch is currently processing your Flipnote. Check back again later."
+msgstr "MusicMatchの処理をしています。時間をおいて確認してください。"
 
 msgid "EDIT_PAGE_MUSICMATCH_NONE_CORRECT"
-msgstr "None of these are correct"
+msgstr "曲名に間違いがある"
 
 msgid "EDIT_PAGE_MUSICMATCH_PREVIEW_ON_YOUTUBE"
-msgstr "Preview on YouTube Music"
+msgstr "YouTube Musicで聴く"
 
 msgid "EDIT_PAGE_MUSICMATCH_PREVIEW_ON_SPOTIFY"
-msgstr "Preview on Spotify"
+msgstr "Spotifyで聴く"
 
 # Browse Song
 
 msgid "BROWSE_SONG_NO_FLIPNOTES_YET"
-msgstr "There have been no Flipnotes posted with this song yet."
+msgstr "この曲が使われた作品はまだありません。"
 
 ## Referring to a music label/publishing company
 msgid "MUSIC_LABEL"
-msgstr "Label"
+msgstr "レーベル"
 
 # Browse Channel
 
 msgid "BROWSE_CHANNEL_NO_FLIPNOTES_YET"
-msgstr "There have been no Flipnotes posted to this channel yet."
+msgstr "このチャンネルに投稿された作品はまだありません。"
 
 ## Posting permissions
 msgid "CHANNEL_PERM_CLOSED"
-msgstr "Closed"
+msgstr "閉じる"
 
 msgid "CHANNEL_PERM_OPEN"
-msgstr "Open"
+msgstr "開く"
 
 ## categories
 
 msgid "CHANNEL_CAT_NAME_NONE"
-msgstr "None"
+msgstr "なし"
 
 msgid "CHANNEL_CAT_NAME_ART"
-msgstr "Art"
+msgstr "アート"
 
 msgid "CHANNEL_CAT_NAME_GENRES"
-msgstr "Genres"
+msgstr "ジャンル"
 
 msgid "CHANNEL_CAT_NAME_TOPICS"
-msgstr "Topics"
+msgstr "トピック"
 
 msgid "CHANNEL_CAT_NAME_ROLEPLAYS"
-msgstr "Roleplays"
+msgstr "ロールプレイング"
 
 msgid "CHANNEL_CAT_NAME_FANDOMS"
-msgstr "Fandoms"
+msgstr "ファン作品"
 
 msgid "CHANNEL_CAT_NAME_RESOURCES"
-msgstr "Resources"
+msgstr "素材"
 
 msgid "CHANNEL_CAT_NAME_PERSONAL"
-msgstr "Personal"
+msgstr "チャット・企画"
 
 msgid "CHANNEL_CAT_NAME_WEEKLY_TOPIC"
-msgstr "Weekly Topic"
+msgstr "今週のお題"
 
 
 # 404 Page
 
 msgid "404_OOPS_NOT_FOUND"
-msgstr "Oops - That page couldn't be found"
+msgstr "エラー！ページが見つかりませんでした"
 
 msgid "404_WHOOPS_NOT_THERE"
-msgstr "Whoops! Whatever you were looking for, it wasn't there."
+msgstr "このページには表示できるものがありません。"
 
 msgid "404_GO_BACK"
-msgstr "Back to Sudomemo Theatre"
+msgstr "スドメモシアターに戻る"
 
 # Sudomemo Shop
 
 msgid "TICKETS"
-msgstr "Tickets"
+msgstr "チケット"
 
 msgid "SUDOMEMO_SHOP_ABOUT_TICKETS_1"
-msgstr "Tickets are fun items on Sudomemo that you can redeem for Stars, Sudomemo Plus, and other things!"
+msgstr "チケットはスターとの交換やスドメモプラスの利用など様々な特典があるスドメモのアイテムです！"
 
 msgid "SUDOMEMO_SHOP_ABOUT_TICKETS_2"
-msgstr "Once you have a ticket, you can redeem it in your Creator's Room by tapping on \"Redeem\" - or, you can give a ticket code as a gift to a friend!"
+msgstr "手に入れたチケットはマイルームから「引き換え」を押して交換するほか、チケットコードを友達にプレゼントすることもできます！"
 
 msgid "SUDOMEMO_SHOP_LEARN_ABOUT_PLUS"
-msgstr "Learn about what you can do with Sudomemo Plus:"
+msgstr "スドメモプラスでできることについて詳しくはこちらをクリック："
 
 msgid "SUDOMEMO_SHOP_ALL_ABOUT_PLUS"
-msgstr "All About Sudomemo Plus"
+msgstr "スドメモプラスについて"
 
 ## Ticket types..
 
 msgid "TICKET_NAME_one_month_plus_ticket"
-msgstr "Plus Ticket (One Month)"
+msgstr "プラスチケット（１ヵ月）"
 
 msgid "TICKET_DESC_one_month_plus_ticket"
-msgstr "This ticket will give you one month of Sudomemo Plus!"
+msgstr "スドメモプラスを１ヵ月間利用できるチケットです！"
 
 msgid "TICKET_NAME_one_year_plus_ticket"
-msgstr "Plus Ticket (One Year)"
+msgstr "プラスチケット（1年）"
 
 msgid "TICKET_DESC_one_year_plus_ticket"
-msgstr "This ticket will give you one year of Sudomemo Plus!"
+msgstr "スドメモプラスを１年間利用できるチケットです！"
 
 # Login Page
 
 msgid "LOGIN_FAILED_CHECK_DETAILS"
-msgstr "We couldn't log you in. Check the details you entered and try again."
+msgstr "ログインできませんでした。入力内容を確認してもう一度送信してください"
 
 msgid "LOGIN_PLACEHOLDER_USERNAME"
-msgstr "Email or Flipnote Studio ID"
+msgstr "E-mailまたはうごメモID"
 
 msgid "LOGIN_PLACEHOLDER_PASSWORD"
-msgstr "Password"
+msgstr "パスワード"
 
 msgid "LOGIN_SIGNUP_SELECT_DEVICE"
-msgstr "Select your device"
+msgstr "機種を選択してください"
 
 msgid "NINTENDO_DSI"
 msgstr "Nintendo DSi"
@@ -722,4 +722,4 @@ msgstr "Nintendo 3DS"
 
 # See Flipnotes with the song <song name> by <band/artist name>
 msgid "BROWSE_SONG_YOU_ARE_BROWSING_SONG"
-msgstr "See Flipnotes with the song %s by %s"
+msgstr "%s / %sが使われている作品"

--- a/ja_JP/LC_MESSAGES/theatre.po
+++ b/ja_JP/LC_MESSAGES/theatre.po
@@ -8,7 +8,7 @@ msgid "SUDOMEMO_THEATRE"
 msgstr "スドメモシアター"
 
 msgid "SUDOMEMO_NEWS"
-msgstr "スドメモニュース"
+msgstr "スドメモニュー"
 
 msgid "SUDOMEMO_SHOP"
 msgstr "スドメモショップ"

--- a/ja_JP/LC_MESSAGES/theatre.po
+++ b/ja_JP/LC_MESSAGES/theatre.po
@@ -8,7 +8,7 @@ msgid "SUDOMEMO_THEATRE"
 msgstr "スドメモシアター"
 
 msgid "SUDOMEMO_NEWS"
-msgstr "スドメモニュー"
+msgstr "スドメモニュース"
 
 msgid "SUDOMEMO_SHOP"
 msgstr "スドメモショップ"
@@ -591,7 +591,7 @@ msgid "EDIT_PAGE_MUSICMATCH_UNMATCHED"
 msgstr "この作品に使用された楽曲は見つかりませんでした。"
 
 msgid "EDIT_PAGE_MUSICMATCH_UNMAPPED"
-msgst "MusicMatchの処理を開始します。時間をおいて確認してください。"
+msgstr "MusicMatchの処理を開始します。時間をおいて確認してください。"
 
 msgid "EDIT_PAGE_MUSICMATCH_PENDING_MAPPING"
 msgstr "MusicMatchの処理をしています。時間をおいて確認してください。"


### PR DESCRIPTION
For the translation of some words, I priority used the words used to be used in Flipnote Hatena.
(e.g. Follow→お気に入りに登録(add to favorite), original Fripnote→親作品(parent's work) etc)

I couldn't come up with a good translation of "Happy Flipnoting!". Therefore I didn't translate it.
(“Happy うごライフ！” (うごライフ : Flipnote+life) is one of the translations I thought of, but I also think it's not bad to not to be translated. I'd like to hear the opinion from other translator...)

Some words were difficult to translate by themselves, so I'll correct them later if they inappropriate.