### PR TITLE
Updates to en_GB translation

### DIFF
--- a/en_GB/LC_MESSAGES/blockSettings.po
+++ b/en_GB/LC_MESSAGES/blockSettings.po
@@ -17,13 +17,13 @@ msgid "USER_HAS_BEEN_BLOCKED"
 msgstr "This user has been blocked."
 
 msgid "IF_YOU_WISH_TO_UNBLOCK"
-msgstr "If you should ever wish to unblock them, you may unblock them by visiting your Creator's Room and opening the Blocked Users menu."
+msgstr "If you should ever wish to unblock them, you can unblock them by visiting your Creator's Room and opening the Blocked Users menu."
 
 msgid "CONFIRM_BLOCK"
 msgstr "Confirm Block"
 
 msgid "USER_ALREADY_BLOCKED"
-msgstr "You have already blocked this user. You may unblock them from the Settings menu in your Creator's Room, but you must wait 24 hours before you can block them again."
+msgstr "You have already blocked this user. You can unblock them from the Settings menu in your Creator's Room, but you must wait 24 hours before you can block them again."
 
 msgid "ONE_DAY_WAIT_BEFORE_REBLOCK_FORMAT"
 msgstr "You have recently unblocked this user. You cannot block them again until %s"

--- a/en_GB/LC_MESSAGES/channelDetails.po
+++ b/en_GB/LC_MESSAGES/channelDetails.po
@@ -29,10 +29,10 @@ msgid "FLIPNOTE_DATA_CORRUPTED"
 msgstr "The Flipnote data is corrupted. Try again in a moment."
 
 msgid "NO_BLANK_FLIPNOTES_ALLOWED"
-msgstr "You may not post an empty Flipnote."
+msgstr "You cannot post an empty Flipnote."
 
 msgid "CONFIRM_EMAIL_BEFORE_POSTING"
 msgstr "Please confirm your email before posting."
 
 msgid "NO_POSTS_WHILE_MUTED"
-msgstr "You may not post while you are muted."
+msgstr "You cannot post while you are muted."

--- a/en_GB/LC_MESSAGES/chatrooms.po
+++ b/en_GB/LC_MESSAGES/chatrooms.po
@@ -29,7 +29,7 @@ msgid "FLIPNOTE_DATA_CORRUPTED"
 msgstr "The Flipnote data is corrupted. Try again in a moment."
 
 msgid "NO_CHAT_MESSAGES_WHILE_MUTED"
-msgstr "You have been muted. You may not chat."
+msgstr "You have been muted, so you cannot chat."
 
 msgid "DUPLICATE_COMMENT_FAILED"
 msgstr "This comment has already been posted to Sudomemo."

--- a/en_GB/LC_MESSAGES/detailsPage.po
+++ b/en_GB/LC_MESSAGES/detailsPage.po
@@ -1,5 +1,5 @@
 msgid "TIMESTAMP_FORMAT"
-msgstr "j/m/Y, g:i:s a"
+msgstr "d/m/Y H:i:s"
 
 msgid "FLIPNOTE_TITLE_FORMAT"
 msgstr "Flipnote by %s"

--- a/en_GB/LC_MESSAGES/flipnoteComments.po
+++ b/en_GB/LC_MESSAGES/flipnoteComments.po
@@ -23,7 +23,7 @@ msgid "LOGIN_REQUIRED_TO_POST_COMMENT"
 msgstr "You must be logged in to post a comment."
 
 msgid "COMMENT_POST_FAILED"
-msgstr "Comment post failed. Try again in a moment."
+msgstr "Failed to post comment. Try again in a moment."
 
 msgid "NO_BLANK_COMMENTS_ALLOWED"
 msgstr "You cannot post a blank comment."
@@ -32,10 +32,10 @@ msgid "FLIPNOTE_DATA_CORRUPTED"
 msgstr "The Flipnote data is corrupted. Try again in a moment."
 
 msgid "FLIPNOTE_COMMENTS_DISALLOWED"
-msgstr "You may not comment on this Flipnote."
+msgstr "You cannot comment on this Flipnote."
 
 msgid "NO_COMMENTS_WHILE_MUTED"
-msgstr "You've been muted. You may not comment."
+msgstr "You've been muted, so you cannot comment."
 
 msgid "DUPLICATE_COMMENT_FAILED"
 msgstr "This comment has already been posted to Sudomemo."

--- a/en_GB/LC_MESSAGES/happyBirthdayEmail.po
+++ b/en_GB/LC_MESSAGES/happyBirthdayEmail.po
@@ -11,4 +11,4 @@ msgid "SPECIAL_SURPRISE_WAITING"
 msgstr "There's a special birthday surprise waiting for you on Sudomemo."
 
 msgid "LOGON_ON_DS_TO_VIEW"
-msgstr "Log on to Sudomemo with your Nintendo DSi or 3DS to receive your birthday gift!"
+msgstr "Log on to Sudomemo with your Nintendo DSi or 3DS to receive your birthday present!"

--- a/en_GB/LC_MESSAGES/login.po
+++ b/en_GB/LC_MESSAGES/login.po
@@ -2,7 +2,7 @@ msgid "BAN_GREETING_FORMAT"
 msgstr "Hello, %s."
 
 msgid "BAN_NOTICE_CONSOLE_BAN"
-msgstr "Your account and console have been suspended from Sudomemo."
+msgstr "Your account and console have been suspended from accessing Sudomemo."
 
 msgid "BAN_NOTICE_PLEASE_READ_BAN_LETTER"
 msgstr "Please read the letter we sent you for further information."
@@ -32,7 +32,7 @@ msgid "WELCOME_BACK_FORMAT"
 msgstr "Welcome back, %s!"
 
 msgid "RETURNING_USER_NEW_LOGIN_SYSTEM"
-msgstr "Since the last time you visited, we've added a new login system -- but don't worry, all of your content is still here!"
+msgstr "Since the last time you visited we've added a new login system -- but don't worry, all of your content is still here!"
 
 msgid "RETURNING_USER_PLEASE_CREATE_PASSWORD"
 msgstr "To get started, please create a new password below."
@@ -56,7 +56,7 @@ msgid "FORM_WARNING_PASSWORD_DISALLOWED_CHARS"
 msgstr "Your password cannot contain any of these characters:"
 
 msgid "FORM_LABEL_DONT_FORGET_PASSWORD"
-msgstr "Remember to make a note of your password, and keep it safe!"
+msgstr "Remember to note down your password and keep it somewhere safe!"
 
 msgid "FORM_HEADER_EMAIL"
 msgstr "Email:"
@@ -68,10 +68,10 @@ msgid "FORM_WARNING_EMAIL_INVALID"
 msgstr "The email address you entered isn't valid."
 
 msgid "EMAIL_ADDITION_SUGGESTED"
-msgstr "Email is optional, but highly recommended. If you ever forget your password, we will send a password reset link to your email address."
+msgstr "Email is optional, but highly recommended. If you ever forget your password, we'll send a password reset link to your email address."
 
 msgid "EMAIL_ADDITION_DETAILS"
-msgstr "If you ever forget your password, we will send a password reset link to your email address."
+msgstr "If you ever forget your password, we'll send a password reset link to your email address."
 
 msgid "CONFIRM_INFO_CORRECT"
 msgstr "Please make sure that the information below is correct."
@@ -164,13 +164,13 @@ msgid "BASIC_AUTH_BAD_LENGTH_FORMAT"
 msgstr "The ID appears to be %s digits in length (should be 16)"
 
 msgid "BASIC_AUTH_LOWERCASE_LETTERS"
-msgstr "The ID contain lowercase letters - it should be all uppercase."
+msgstr "The ID contains lowercase letters - it should be all uppercase."
 
 msgid "BASIC_AUTH_NONHEX_CHARACTERS"
-msgstr "The ID contains characters other than 0-9 and A-F (it should only contain 0-9 and A-F)."
+msgstr "The ID contains characters other than 0-9 and A-F (other characters are never used)."
 
 msgid "SEEK_LOGIN_HELP_IN_DISCORD_FORMAT"
-msgstr "If you need help connecting, feel free to ask in our Discord! You can join from %s."
+msgstr "If you need help connecting, feel free to ask in our Discord server! You can join from %s."
 
 msgid "BAN_NOTICE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
 msgstr "Please contact us on Discord or via email to %s."
@@ -203,13 +203,13 @@ msgid "BUTTON_RESEND_VERIFICATION_EMAIL"
 msgstr "Resend Verification Email"
 
 msgid "NOT_RECEIVING_HELP_FORMAT"
-msgstr "Not receiving the email? You can reach out to us on the Sudomemo Discord or via %s."
+msgstr "Not receiving the email? You can reach out to us on the Sudomemo Discord server or via %s."
 
 msgid "HEADER_VERIFY_EMAIL"
 msgstr "Verify Email"
 
 msgid "VERIFICATION_LIMIT_EXCEEDED_FORMAT"
-msgstr "You have exceeded the maximum number of verification emails. Please contact support at %s or via Discord."
+msgstr "You have exceeded the maximum number of verification attempts. Please contact support at %s or via Discord."
 
 msgid "WEB_HEADER_SUCCESS"
 msgstr "Success!"
@@ -239,9 +239,9 @@ msgid "BUTTON_EDIT_EMAIL_ADDRESS"
 msgstr "Change Email Address"
 
 msgid "SEARCH_FOR_SENDER_EMAIL_FORMAT"
-msgstr "Haven't received the email? Check your Spam box, and search for %s. If you find that it was marked spam, please ensure you first mark it Not Spam."
+msgstr "Haven't received the email? Check your Junk or Spam inbox, and search for %s. If you find that it was marked spam, please ensure you first mark it as safe, Not Spam, and/or Not Junk."
 
 msgid "NEW_USER_INTRO_POST_INTRO_CHANNEL"
-msgstr "When you're ready, go ahead and introduce yourself in our Introduction channel, under the Personal category."
+msgstr "When you're ready, why not go ahead and introduce yourself in our Introduction channel? You can find it under the Personal category."
 msgid "EMAIL_VERIFICATION_ADDRESS_REMOVED"
 msgstr "Sorry about that! We've marked that email address as incorrect, so you shouldn't receive any further emails from Sudomemo."

--- a/en_GB/LC_MESSAGES/mail_content_removed.po
+++ b/en_GB/LC_MESSAGES/mail_content_removed.po
@@ -55,7 +55,7 @@ msgstr "Content ID:"
 ## re-download will be made available for certain content types
 
 msgid "REDOWNLOAD_HEADER"
-msgstr "If you would like to revise your %s, you may download it %s"
+msgstr "If you would like to revise your %s, you can download it %s"
 
 msgid "REDOWNLOAD_LINK"
 msgstr "here"

--- a/en_GB/LC_MESSAGES/menuHeaders.po
+++ b/en_GB/LC_MESSAGES/menuHeaders.po
@@ -56,7 +56,7 @@ msgid "MAIL"
 msgstr "Mail"
 
 msgid "TEST_TRANSLATION"
-msgstr "English Translation"
+msgstr "British English Translation"
 
 msgid "HELP"
 msgstr "Help"

--- a/en_GB/LC_MESSAGES/passwordResetEmail.po
+++ b/en_GB/LC_MESSAGES/passwordResetEmail.po
@@ -14,7 +14,7 @@ msgid "TEXT_RESET_LINK_FORMAT"
 msgstr "Click <a target=\"_blank\" href=\"%s\">here</a> to continue."
 
 msgid "TEXT_URL_PLAIN_DISPLAY"
-msgstr "You may also copy and paste this URL into a new window:"
+msgstr "You can alternatively copy and paste this URL into a new window:"
 
 msgid "PASSWORD_RESET_SENT_FORMAT"
 msgstr "A password reset request has been sent to the email address %s."

--- a/en_GB/LC_MESSAGES/reportContent.po
+++ b/en_GB/LC_MESSAGES/reportContent.po
@@ -35,13 +35,13 @@ msgid "NO_BLANK_REPORTS"
 msgstr "You cannot post a blank report."
 
 msgid "LIMIT_ONE_REPORT"
-msgstr "Please note: You may only report this content one time. Additional reports will not be registered, so please put your information in a single comment."
+msgstr "Please note: You can only report this content once. Additional reports will not be registered, so please put your information in a single comment."
 
 msgid "REPORT_EXPLANATION_FAILED"
 msgstr "An error occurred while this report was being submitted."
 
 msgid "RESTRICTED_CANCEL"
-msgstr "You may not report content if you have been restricted from interacting with Sudomemo in any way."
+msgstr "You cannot report content if you have been restricted from interacting with Sudomemo in any way."
 
 msgid "HEADER_REASON"
 msgstr "Reason:"

--- a/en_GB/LC_MESSAGES/search.po
+++ b/en_GB/LC_MESSAGES/search.po
@@ -41,4 +41,4 @@ msgid "SHORT_KEY_FORMAT_GUIDE"
 msgstr "Not finding what you're looking for? You may have entered the Flipnote ID incorrectly. Flipnote IDs are six digits long and can be found in the details section for the Flipnote."
 
 msgid "SHORT_KEY_SIMILAR_FOUND_CASE_SENSITIVE"
-msgstr "No result was found, but a similar ID exists. Please note that Flipnote IDs are case-sensitive, and usually all-capital letters and numbers."
+msgstr "No result was found, but a similar ID exists. Please note that Flipnote IDs are case-sensitive and usually only numbers and capital letters."

--- a/en_GB/LC_MESSAGES/theatre.po
+++ b/en_GB/LC_MESSAGES/theatre.po
@@ -40,12 +40,12 @@ msgstr "%s - %s fans, %s Flipnotes on Sudomemo"
 # Wednesday, December 3rd, 2019
 # Used for news articles
 msgid "DATETIME_WEEKDAY_MONTH_DAY_ORDINAL_YEAR_FORMAT"
-msgstr "l, F jS, Y"
+msgstr "l j F Y"
 
 # November 29th, 2019 08:23:07
 # Used for Flipnote Details
 msgid "DATETIME_MONTH_DAY_ORDINAL_HOUR_MINUTE_SECOND_FORMAT"
-msgstr "F jS, Y h:i:s"
+msgstr "j F Y H:i:s"
 
 # Very common terms and one-word translations
 
@@ -176,7 +176,7 @@ msgid "SHARE"
 msgstr "Share"
 
 msgid "SIGN_UP"
-msgstr "Sign Up"
+msgstr "Sign up"
 
 msgid "SIGN_IN"
 msgstr "Sign in"
@@ -674,7 +674,7 @@ msgid "SUDOMEMO_SHOP_ABOUT_TICKETS_1"
 msgstr "Tickets are fun items on Sudomemo that you can redeem for Stars, Sudomemo Plus, and other things!"
 
 msgid "SUDOMEMO_SHOP_ABOUT_TICKETS_2"
-msgstr "Once you have a ticket, you can redeem it in your Creator's Room by tapping on \"Redeem\" - or, you can give a ticket code as a gift to a friend!"
+msgstr "Once you have a ticket, you can redeem it in your Creator's Room by tapping on \"Redeem\" - or, you can give a ticket code as a present to a friend!"
 
 msgid "SUDOMEMO_SHOP_LEARN_ABOUT_PLUS"
 msgstr "Learn about what you can do with Sudomemo Plus:"

--- a/en_GB/LC_MESSAGES/themeShop.po
+++ b/en_GB/LC_MESSAGES/themeShop.po
@@ -71,7 +71,7 @@ msgid "THEME_SHOP_STAR_BALANCE_TOO_LOW"
 msgstr "Sorry, you don't have enough Green Stars for this theme."
 
 msgid "THEME_SHOP_CHOOSE_CAREFULLY_BEFORE_BUYING"
-msgstr "All purchases are permanent, please choose carefully before buying!"
+msgstr "All purchases are permanent, so please choose carefully before buying!"
 
 msgid "THEME_SHOP_YOU_OWN_THIS_THEME"
 msgstr "You already own this theme."

--- a/en_GB/LC_MESSAGES/tickets.po
+++ b/en_GB/LC_MESSAGES/tickets.po
@@ -148,7 +148,7 @@ msgid "TICKET_NAME_special_someone_ticket"
 msgstr "Special Someone Ticket"
 
 msgid "TICKET_DESC_special_someone_ticket"
-msgstr "For that special someone. Three months of Plus, Color Stars, and an exclusive theme."
+msgstr "For that special someone. Three months of Plus, Colour Stars, and an exclusive theme."
 
 msgid "TICKET_NAME_folding_reward_ticket"
 msgstr "Folding@Home Reward Ticket"
@@ -190,7 +190,7 @@ msgid "TICKET_NAME_translator_ticket"
 msgstr "Translator Ticket"
 
 msgid "TICKET_DESC_translator_ticket"
-msgstr "Thank you for helping localize Sudomemo!"
+msgstr "Thank you for helping localise Sudomemo!"
 
 msgid "TICKET_NAME_colors_promo_ticket"
 msgstr "Colors! Promo Ticket"

--- a/en_GB/LC_MESSAGES/trophies.po
+++ b/en_GB/LC_MESSAGES/trophies.po
@@ -32,7 +32,7 @@ msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
 msgid "TROPHY_DESC_featured_artist"
-msgstr "Get recognized as a Sudomemo Featured Artist"
+msgstr "Get recognised as a Sudomemo Featured Artist"
 
 msgid "TROPHY_NAME_featured_flipnote"
 msgstr "Featured Flipnote"

--- a/en_GB/LC_MESSAGES/unfulfilledSignupEmail.po
+++ b/en_GB/LC_MESSAGES/unfulfilledSignupEmail.po
@@ -14,4 +14,4 @@ msgid "TEXT_VERIFICATION_LINK_FORMAT"
 msgstr "Click <a target=\"_blank\" href=\"%s\">here</a> to continue!"
 
 msgid "TEXT_URL_PLAIN_DISPLAY"
-msgstr "You may also copy and paste this URL into a new window:"
+msgstr "You can also copy and paste this URL into a new window:"


### PR DESCRIPTION
Changes in wording for 'can' vs 'may' to reflect the norm in British English, along with some rephrasing to sound more natural throughout. Also updated spellings for new strings.

(FSID: `96FAD88031C49DE1`)

Signed-off-by: Lauren Kelly <lauren.kelly@msn.com>