### PR TITLE
pl_PL: correct ticket drawing text

### DIFF
--- a/pl_PL/LC_MESSAGES/creatorsRoom.po
+++ b/pl_PL/LC_MESSAGES/creatorsRoom.po
@@ -197,7 +197,7 @@ msgid "TICKET_COOLDOWN_MESSAGE_FORMAT"
 msgstr "Możesz wylosować kolejny bilet za: %s godzin(y) %s minut(y)."
 
 msgid "REDEEM"
-msgstr "Wykorzystaj"
+msgstr "Wykorzystaj kod"
 
 msgid "SPENDABLE_STARS"
 msgstr "Twoje gwiazdki"

--- a/pl_PL/LC_MESSAGES/creatorsRoom.po
+++ b/pl_PL/LC_MESSAGES/creatorsRoom.po
@@ -185,16 +185,16 @@ msgid "TICKET_SECTION"
 msgstr "Bilety"
 
 msgid "DRAW_REGULAR_TICKET"
-msgstr "Bilet"
+msgstr "Wylosuj bilet"
 
 msgid "CAN_DRAW_TICKET_SUBTEXT"
-msgstr "Masz możliwość wykorzystania biletu! Kto wie, może coś wygrasz?"
+msgstr "Masz możliwość wylosowania zwykłego biletu! Kto wie, może coś wygrasz?"
 
 msgid "INVENTORY"
 msgstr "Ekwipunek"
 
 msgid "TICKET_COOLDOWN_MESSAGE_FORMAT"
-msgstr "Możesz wykorzystać kolejny bilet za: %s godzin(y) %s minut(y)."
+msgstr "Możesz wylosować kolejny bilet za: %s godzin(y) %s minut(y)."
 
 msgid "REDEEM"
 msgstr "Wykorzystaj"


### PR DESCRIPTION
This PR corrects text in the Creator's Room related to drawing a ticket. (I previously thought this was just a message that appeared when you could use a ticket in your inventory, not getting a free regular ticket.)