### PR TITLE
Update French translation + identical strings list

### DIFF
--- a/fr_FR/LC_MESSAGES/common_ds.po
+++ b/fr_FR/LC_MESSAGES/common_ds.po
@@ -4,10 +4,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "NOT_LOGGED_IN_NOTICE"
-msgstr "You aren't logged in to Sudomemo - tap %s to continue!"
+msgstr "Vous n'êtes pas connecté à Sudomemo - appuyez %s pour continuer !"
 
 msgid "NOT_LOGGED_IN_NOTICE_LINK_TEXT"
-msgstr "here"
+msgstr "ici"
 
 msgid "YOU_HAVE_NEW_NOTIFICATIONS"
-msgstr "You have new notifications"
+msgstr "Vous avez de nouvelles notifications"

--- a/fr_FR/LC_MESSAGES/theatre.po
+++ b/fr_FR/LC_MESSAGES/theatre.po
@@ -108,7 +108,7 @@ msgstr "FSID"
 
 # Japanese translation should also be be うごメモID here
 msgid "FLIPNOTE_STUDIO_ID"
-msgstr "Flipnote Studio ID"
+msgstr "ID Flipnote Studio"
 
 msgid "GENRE"
 msgstr "Genre"

--- a/fr_FR/LC_MESSAGES/theatre.po
+++ b/fr_FR/LC_MESSAGES/theatre.po
@@ -156,7 +156,7 @@ msgstr "Aléatoire"
 
 # Referring to a release date/publishing date
 msgid "RELEASED"
-msgstr "Released"
+msgstr "Date de sortie"
 
 msgid "RANK"
 msgstr "Rang"
@@ -193,7 +193,7 @@ msgstr "Titre"
 
 # Referring to being the most popular (in terms of ranking)
 msgid "TOP"
-msgstr "Top"
+msgstr "Les plus populaires"
 
 # Number of times something has been viewed, or played.
 msgid "VIEWS"
@@ -888,10 +888,10 @@ msgid "YOUTUBE_CHECK_FEATURES_THUMB"
 msgstr "Votre chaîne YouTube n'est peut-être pas complètement vérifiée. Pour plus d'informations, vous pouvez vérifier le statut des miniatures personnalisées ici :"
 
 msgid "YOUTUBE_REFRESH_ACCOUNT"
-msgstr "Refresh account"
+msgstr "Actualiser le compte"
 
 msgid "YOUTUBE_UNLINK_ACCOUNT"
-msgstr "Unlink account"
+msgstr "Dissocier le compte"
 
 msgid "YOUTUBE_UNLINK_ACCOUNT_CONFIRM"
-msgstr "Are you sure you want to remove your linked YouTube channel?"
+msgstr "Êtes-vous sûr de vouloir dissocier votre chaîne YouTube ?"

--- a/fr_FR/LC_MESSAGES/themeShop.po
+++ b/fr_FR/LC_MESSAGES/themeShop.po
@@ -109,4 +109,4 @@ msgid "THEME_SHOP"
 msgstr "Boutique de thèmes"
 
 msgid "DETAILS"
-msgstr "Details"
+msgstr "Détails"


### PR DESCRIPTION
Hi, I have translated the following strings:

fr_FR/LC_MESSAGES/common_ds.po:
- NOT_LOGGED_IN_NOTICE
- NOT_LOGGED_IN_NOTICE_LINK_TEXT
- YOU_HAVE_NEW_NOTIFICATIONS

fr_FR/LC_MESSAGES/theatre.po:
- FLIPNOTE_STUDIO_ID
- RELEASED
- TOP
- YOUTUBE_REFRESH_ACCOUNT
- YOUTUBE_UNLINK_ACCOUNT
- YOUTUBE_UNLINK_ACCOUNT_CONFIRM

fr_FR/LC_MESSAGES/themeShop.po:
- DETAILS


### Identical strings (don't need translation):

fr_FR/LC_MESSAGES/browseChannel.po:
- PAGE

fr_FR/LC_MESSAGES/browseFlipnotes.po:
- SUDOMEMO
- HEADER_FLIPNOTES
- HEADER_PAGE
- PAGE

fr_FR/LC_MESSAGES/channelCategories.po:
- ART
- GENRES
- FANDOMS

fr_FR/LC_MESSAGES/channelDetails.po:
- FLIPNOTES

fr_FR/LC_MESSAGES/channelList.po:
- PAGE

fr_FR/LC_MESSAGES/chatrooms.po:
- PAGE_FORMAT

fr_FR/LC_MESSAGES/creatorsRoom.po:
- FANS
- TICKET_SECTION
- PAGE

fr_FR/LC_MESSAGES/dailyStarReport.po:
- STRING_SUDOMEMO

fr_FR/LC_MESSAGES/detailsPage.po:
- HEADER_OPTIONS
- HEADER_DESCRIPTION
- HEADER_FLIPNOTE_OPTIONS

fr_FR/LC_MESSAGES/flipnoteComments.po:
- PAGE_FORMAT

fr_FR/LC_MESSAGES/flipnoteOptions.po:
- HEADER_OPTION

fr_FR/LC_MESSAGES/followNotificationEmail.po:
- STATS_FLIPNOTES_FORMAT
- STATS_FLIPNOTES_FORMAT_SINGULAR

fr_FR/LC_MESSAGES/mail_content_removed.po:
- CONTENT_TYPE_flipnote

fr_FR/LC_MESSAGES/mail_content_restored.po:
- CONTENT_TYPE_flipnote

fr_FR/LC_MESSAGES/mail.po:
- TITLE_MESSAGE
- TITLE_INFO

fr_FR/LC_MESSAGES/mail_report_accepted.po:
- CONTENT_TYPE_flipnote

fr_FR/LC_MESSAGES/mail_report_rejected.po:
- CONTENT_TYPE_flipnote

fr_FR/LC_MESSAGES/mailSettings.po:
- MAIL_TYPE
- TYPE_PROMO_NAME

fr_FR/LC_MESSAGES/menuHeaders.po:
- MAIL

fr_FR/LC_MESSAGES/musicMatch.po:
- GENRE
- FLIPNOTE_COUNT

fr_FR/LC_MESSAGES/reportContent.po:
- FLIPNOTE
- CATEGORY_NAME_spam

fr_FR/LC_MESSAGES/search.po:
- PAGE_FORMAT

fr_FR/LC_MESSAGES/sudomemoNewsBrowser.po:
- PAGE_FORMAT

fr_FR/LC_MESSAGES/theatre.po:
- SUDOMEMO
- SUDOMEMO_THEATRE
- DESCRIPTION
- FANS
- FLIPNOTE
- FLIPNOTES
- FSID
- GENRE
- MUSICMATCH
- PERMISSIONS
- SUDOMEMO_PLUS
- NAVBAR_ITEM_DISCORD
- NAVBAR_ITEM_TWITTER
- NAVBAR_ITEM_INSTAGRAM
- NAVBAR_ITEM_FACEBOOK
- NAVBAR_ITEM_EMAIL
- NAVBAR_ITEM_ADMIN
- NAVBAR_ITEM_SUDOMEMO_ADMIN
- MUSIC_LABEL
- CHANNEL_CAT_NAME_ART
- CHANNEL_CAT_NAME_GENRES
- CHANNEL_CAT_NAME_FANDOMS
- TICKETS
- NINTENDO_DSI
- NINTENDO_3DS
- YOUTUBE
- YOUTUBE_TAGS

fr_FR/LC_MESSAGES/themeShop.po:
- DESCRIPTION

fr_FR/LC_MESSAGES/tickets.po:
- SUDOMEMO_PLUS

fr_FR/LC_MESSAGES/userMovieList.po:
- PAGE

fr_FR/LC_MESSAGES/youtube.po:
- YOUTUBE
- PREVIEW_DESC
- TAGS