### PR TITLE
Added full Spanish translations and updated a few ones.

### DIFF
--- a/es_ES/LC_MESSAGES/404.po
+++ b/es_ES/LC_MESSAGES/404.po
@@ -4,13 +4,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "CANT_FIND_THAT_USER"
-msgstr "Argh! Where are they? I can't seem to find that user."
+msgstr "¡Argh! ¿Quién sera? No encuentro a ese usuario..."
 
 msgid "FLIPNOTE_NOT_FOUND"
-msgstr "Whoops! I couldn't find that Flipnote..."
+msgstr "¡Vaya! No veo esa Flipnote por ningún lado..."
 
 msgid "I_CANT_FIND_THEM"
-msgstr "I can't find them!"
+msgstr "¡No le veo!"
 
 msgid "WHERE_IS_IT"
-msgstr "Where is it?"
+msgstr "¿Donde está?"

--- a/es_ES/LC_MESSAGES/blockSettings.po
+++ b/es_ES/LC_MESSAGES/blockSettings.po
@@ -4,25 +4,25 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "BLOCKED_USERS"
-msgstr "Usuarios Bloqueados"
+msgstr "Usuarios bloqueados"
 
 msgid "BLOCK_USER"
-msgstr "Bloquear Usuario"
+msgstr "Bloquear usuario"
 
 msgid "CANNOT_UNBLOCK_NONBLOCKED_USER"
 msgstr "No puedes desbloquear este usuario porque no lo tienes bloqueado."
 
 msgid "COMMENTING_ENABLED_AFTER_UNBLOCK"
-msgstr "Después de haber desbloqueado a este usuario, el podrá comentar en tus Flipnotes nuevamente, a menos que el te tenga bloqueado también."
+msgstr "Cuándo desbloquees a este usuario, el podrá comentar en tus Flipnotes y tu en las suyas. Sin embargo, si el usuario te tiene bloqueado, no habrá cambios."
 
 msgid "COMMENT_BLOCK_IS_MUTUAL"
 msgstr "Cuando hayas bloqueado a este usuario no podrás comentar en sus Flipnotes, ni él en las tuyas."
 
 msgid "CONFIRM_BLOCK"
-msgstr "Confirmar Bloqueo"
+msgstr "Confirmar bloqueo"
 
 msgid "CONFIRM_UNBLOCK"
-msgstr "Confirmar Desbloqueo"
+msgstr "Confirmar desbloqueo"
 
 msgid "IF_YOU_WISH_TO_UNBLOCK"
 msgstr "Si quieres desbloquear a un usuario, tendrás que quitarlo de la lista de usuarios bloqueados de tu Sala del Creador."
@@ -43,22 +43,22 @@ msgid "RECENTLY_UNBLOCKED_ONE_DAY_THRESHOLD"
 msgstr "Has desbloqueado recientemente a este usuario, tienes que esperar 24 horas desde la hora del desbloqueo antes de que puedas bloquearlo de nuevo."
 
 msgid "TAP_BACK_TO_RETURN"
-msgstr "Toca Atrás para volver a la Sala del Creador."
+msgstr "Toca «Atrás» para volver a la Sala del Creador."
 
 msgid "UNBLOCK"
-msgstr "Desbloquear"
+msgstr "Desbloq."
 
 msgid "UNBLOCK_USER"
-msgstr "Desbloquear Usuario"
+msgstr "Desbloquear usuario"
 
 msgid "UNBLOCK_WARNING_ONE_DAY_THRESHOLD"
-msgstr "Si has bloqueado al usuario, tendrás que esperar 24 horas antes de poder bloquearlo de nuevo."
+msgstr "Si luego quieres bloquearle otra vez, tendrás que esperar 24 horas a partir del desbloqueo"
 
 msgid "USER_ALREADY_BLOCKED"
-msgstr "Ya has bloqueado a este usuario, podrás desbloquearlo en el menú de usuarios bloqueados de tu Sala del Creador, pero deberás esperar 24 horas si quieres bloquearlo de nuevo."
+msgstr "Este usuario ya está bloqueado. Puedes ir a tu sala y quitarlo de tu lista de bloqueados. Ten en cuenta que deberás esperar 24 horas si luego quieres volver a bloquearlo."
 
 msgid "USER_HAS_BEEN_BLOCKED"
-msgstr "Este usuario ha sido bloqueado."
+msgstr "Usuario bloqueado."
 
 msgid "USER_HAS_BEEN_UNBLOCKED"
 msgstr "Usuario desbloqueado."

--- a/es_ES/LC_MESSAGES/browseChannel.po
+++ b/es_ES/LC_MESSAGES/browseChannel.po
@@ -4,16 +4,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "BROWSE_BY_ALBUM"
-msgstr "Buscar por Album"
+msgstr "Buscar por álbum"
 
 msgid "BROWSE_BY_ARTIST"
-msgstr "Buscar por Artista"
+msgstr "Buscar por artista"
 
 msgid "BROWSE_BY_SONG"
-msgstr "Buscar por Canción"
+msgstr "Buscar por canción"
 
 msgid "BROWSE_PLAYLIST"
-msgstr "Buscar por Lista de Reproducción"
+msgstr "Buscar lista de reproducción"
 
 msgid "NEXT"
 msgstr "Siguiente"
@@ -31,10 +31,10 @@ msgid "PREV"
 msgstr "Anterior"
 
 msgid "SONG_DETAILS"
-msgstr "Detalles de la Canción"
+msgstr "Detalles de la canción"
 
 msgid "SPINOFFS"
 msgstr "Spin-offs"
 
 msgid "UPPERTITLE"
-msgstr "Buscar Canal"
+msgstr "Buscar canal"

--- a/es_ES/LC_MESSAGES/channelCategories.po
+++ b/es_ES/LC_MESSAGES/channelCategories.po
@@ -19,7 +19,7 @@ msgid "RESOURCES"
 msgstr "Recursos"
 
 msgid "ROLEPLAYS"
-msgstr "Juegos de Rol"
+msgstr "Juegos de rol"
 
 msgid "TOPICS"
 msgstr "Temas"

--- a/es_ES/LC_MESSAGES/colorPicker.po
+++ b/es_ES/LC_MESSAGES/colorPicker.po
@@ -10,13 +10,13 @@ msgid "CURRENT_COLOR_DEFAULT"
 msgstr "Color actual: por defecto"
 
 msgid "RETURN"
-msgstr "Regresar"
+msgstr "Volver"
 
 msgid "SELECT_A_COLOR"
 msgstr "Elije un color."
 
 msgid "SET_PAPER_COLOR"
-msgstr "Establecer el color del papel"
+msgstr "Cambiar el color del papel"
 
 msgid "SET_PEN_COLOR"
-msgstr "Establecer el color de la pluma"
+msgstr "Cambiar el color del lápiz"

--- a/es_ES/LC_MESSAGES/creatorsRoom.po
+++ b/es_ES/LC_MESSAGES/creatorsRoom.po
@@ -86,7 +86,7 @@ msgstr "Usabilidad de las funciones"
 
 # Matches button on page 4 of Flipnote Studio settings
 msgid "FLIPNOTE_FRIENDS"
-msgstr "Borrar amigos"
+msgstr "Amigos Flipnote"
 
 msgid "FLIPNOTE_FRIENDS_INFO"
 msgstr "Creators you've exchanged Flipnotes with"

--- a/es_ES/LC_MESSAGES/creatorsRoom.po
+++ b/es_ES/LC_MESSAGES/creatorsRoom.po
@@ -52,13 +52,13 @@ msgid "CHANGE_ROOM_THEME_LINK"
 msgstr "[Cambiar fondo]"
 
 msgid "CREATORS_ROOM"
-msgstr "Sala del Creador"
+msgstr "Sala del creador"
 
 msgid "CURRENT_BIO"
 msgstr "Biografía actual:"
 
 msgid "DRAW_REGULAR_TICKET"
-msgstr "Obtener Ticket"
+msgstr "Obtener ticket"
 
 msgid "ENTER_BIO"
 msgstr "Ingresar biografía..."
@@ -73,20 +73,20 @@ msgid "FAN_COUNT_FORMAT"
 msgstr "Aficionados: %s"
 
 msgid "FAVORITES_FEED"
-msgstr "Flipnotes de tus Usuarios Favoritos"
+msgstr "Flipnotes de tus favoritos"
 
 msgid "FAVORITE_CHANNELS"
-msgstr "Canales Favoritos"
+msgstr "Canales favoritos"
 
 msgid "FAVORITE_USERS"
-msgstr "Usuarios Favoritos"
+msgstr "Usuarios favoritos"
 
 msgid "FEATURE_USABILITY"
 msgstr "Usabilidad de las funciones"
 
 # Matches button on page 4 of Flipnote Studio settings
 msgid "FLIPNOTE_FRIENDS"
-msgstr "Flipnote Friends"
+msgstr "Borrar amigos"
 
 msgid "FLIPNOTE_FRIENDS_INFO"
 msgstr "Creators you've exchanged Flipnotes with"
@@ -113,7 +113,7 @@ msgid "HEADER_MAIL_SETTINGS"
 msgstr "Ajustes de correo"
 
 msgid "HEADER_SUPPORT_TOKEN"
-msgstr "Support Token"
+msgstr "Código de soporte"
 
 msgid "INVENTORY"
 msgstr "Inventario"
@@ -155,7 +155,7 @@ msgid "REDEEM"
 msgstr "Canjear"
 
 msgid "REQUEST"
-msgstr "Request"
+msgstr "Solicitar"
 
 msgid "SEE_MORE"
 msgstr "Ver más..."

--- a/es_ES/LC_MESSAGES/inbox.po
+++ b/es_ES/LC_MESSAGES/inbox.po
@@ -10,8 +10,8 @@ msgid "NEXT"
 msgstr "Sig."
 
 msgid "PREV"
-msgstr "Prev."
+msgstr "Ant."
 
 # this must be a max of 6 characters
 msgid "UNAUTHED_READ"
-msgstr "Leer.."
+msgstr "*Leer*"

--- a/es_ES/LC_MESSAGES/items.po
+++ b/es_ES/LC_MESSAGES/items.po
@@ -4,43 +4,43 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "CONTINUE"
-msgstr "Continue"
+msgstr "Continuar"
 
 msgid "ITEM_DESC_banana"
-msgstr "Not to be confused with a plantain."
+msgstr "No se debe confundir con un plátano."
 
 msgid "ITEM_DESC_beach_ball"
-msgstr "A great accessory for a swimming excursion."
+msgstr "Un gran accesorio para actividades de natación."
 
 msgid "ITEM_DESC_hot_chocolate"
-msgstr "A delicious cup of hot chocolate, perfect for a cozy day."
+msgstr "Una taza de rico chocolate caliente, perfecta para un día de relax."
 
 msgid "ITEM_DESC_peeled_banana"
-msgstr "Not to be confused with a plan-... Why'd you peel it like that?"
+msgstr "No se debe confundir con un pl-... ¿Por qué lo has pelado así?"
 
 msgid "ITEM_NAME_banana"
 msgstr "Banana"
 
 msgid "ITEM_NAME_beach_ball"
-msgstr "Beach Ball"
+msgstr "Pelota de playa"
 
 msgid "ITEM_NAME_hot_chocolate"
-msgstr "Hot Chocolate"
+msgstr "Chocolate caliente"
 
 msgid "ITEM_NAME_peeled_banana"
-msgstr "Peeled Banana"
+msgstr "Banana pelada"
 
 msgid "ITEM_USE_banana"
-msgstr "You peel the banana."
+msgstr "Pelas la banana."
 
 msgid "ITEM_USE_beach_ball"
-msgstr "You toss the ball around a bit."
+msgstr "Lanzas la pelota alrededor unas veces."
 
 msgid "ITEM_USE_hot_chocolate"
-msgstr "After letting it cool for a moment, you drink the hot chocolate"
+msgstr "Después de dejarlo enfriar un rato, te tomas el chocolate."
 
 msgid "ITEM_USE_peeled_banana"
-msgstr "You eat the banana."
+msgstr "Te comes la banana."
 
 msgid "YOU_GOT_AN_ITEM"
-msgstr "You got an item!"
+msgstr "¡Has conseguido un objeto!"

--- a/es_ES/LC_MESSAGES/localeSelection.po
+++ b/es_ES/LC_MESSAGES/localeSelection.po
@@ -4,19 +4,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "CHANGE_LANGUAGE"
-msgstr "Cambiar Idioma"
+msgstr "Cambiar idioma"
 
 msgid "INVALID_LOCALE"
 msgstr "Lo sentimos, pero ese idioma no está disponible."
 
 msgid "LANGUAGE_UPDATED_FORMAT"
-msgstr "Tu idioma ha sido cambiado a %s."
+msgstr "Tu idioma se ha cambiado a %s."
 
 msgid "NOT_LOGGED_IN"
 msgstr "Debes iniciar sesión antes de cambiar tu idioma."
 
 msgid "POTENTIAL_CONTRIBUTOR_NOTE"
-msgstr "Sudomemo confia en su comunidad para proveer traducciones correctas. Si ves algo que no se muestra correctamente, aun está en ingles, es una traducción de baja calidad, o si te gustaria añadir tu propio lenguaje, te invitamos a contribuir! Traducciones completas y verificades te pueden ganar más dias de Sudomemo Plus. Puedes contribuir aqui: "
+msgstr "Sudomemo depende de su comunidad para ofrecer traducciones óptimas. Si ves que algo no se muestra correctamente, que aún está en ingles, que es una traducción de baja calidad, o que simplemente te gustaría añadir un idioma nuevo, ¡te invitamos a contribuir! Traducciones completas y verificades te pueden dar días extra de Sudomemo Plus. Si te interesa, ve aqui: "
 
 msgid "RETURN_TO_CREATORS_ROOM"
 msgstr "Regresar a la Sala del Creador"

--- a/es_ES/LC_MESSAGES/supportToken.po
+++ b/es_ES/LC_MESSAGES/supportToken.po
@@ -4,28 +4,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "DO_NOT_SHARE_TOKEN"
-msgstr "Don't share this token with anyone. If someone reaches out to you claiming to be Sudomemo Support and asks you for this token, don't give it to them."
+msgstr "No compartas este código con nadie. Si alguien te contacta reclamando ser de nuestro equipo de soporte y te pide el código, NO SE LO DES."
 
 msgid "GET_SUPPORT_TOKEN"
-msgstr "Get Support Token"
+msgstr "Obtener código"
 
 msgid "HATENA_ID_VERIFICATION"
-msgstr "Hatena ID Verification"
+msgstr "Verificación del ID de Hatena "
 
 msgid "HATENA_ID_VERIFICATION_INTRO"
-msgstr "This tool allows you to verify ownership of a Hatena ID when working with Sudomemo Support."
+msgstr "Esta herramienta te permite verificar la propiedad de tu ID de Hatena al momento de trabajar con el equipo de soporte."
 
 msgid "HATENA_ID_VERIFICATION_INTRO_2"
-msgstr "You will be prompted to log in to your Hatena Account, after which you will receive a Support Token."
+msgstr "Se te mostrará una ventana para que inicies sesión en Hatena, tras lo cuál recibiras un código de soporte."
 
 msgid "LOGIN_FIRST_BEFORE_SUPPORT_TOKEN"
-msgstr "It looks like you already have an account. Please log in first before requesting a Support Token."
+msgstr "Parece que ya tienes una cuenta. Inicia sesión antes de solicitar el código de soporte."
 
 msgid "SUPPORT_TOKEN"
-msgstr "Support Token"
+msgstr "Código de soporte"
 
 msgid "SUPPORT_TOKEN_INFO"
-msgstr "Here is your Support Token, which you were asked for when you contacted Sudomemo Support."
+msgstr "Aquí está tu código de soporte, el que se te preguntó cuando contactaste con el soporte de Sudomemo."
 
 msgid "YOU_ARE_REQUESTING_SUPPORT_TOKEN"
-msgstr "You are now requesting a Support Token, which is used to verify your identity when you contact Sudomemo Support."
+msgstr "Estas pidiendo un código de soporte, el cuál se usará para confirmar tu idendidad cuando contactes con el equipo de soporte de Sudomemo."


### PR DESCRIPTION
Fully added Spanish on 404.po, items.po, supportToken.po and support token options of creatorsRoom.po.

Minor fixes on blockSettings.po, browseChannel.po, channelCategories.po, colorPicker.po, inbox.po and localeSelection that improves readability by adding a more familiar language. Well I mean... you'll be the judges of that.

Also corrected some characters that were caps and when possible, reduced string length.

To avoid confusion, FLIPNOTE_FRIENDS button in the Spanish version of FS is "Erase friends" instead of "Amigos de Flipnote Studio".

To mention that some translations may be slightly different in meaning (not literal translation even when acceptable) and with a longer string, as sacrifice for more understandable and simple sentences.

If you find an error or if you need anything, reach out to me.


My FSID: 91D6 6E30 5143 095D