### PR TITLE
Updated strings overall (*)

### DIFF
--- a/pt_PT/LC_MESSAGES/archive.po
+++ b/pt_PT/LC_MESSAGES/archive.po
@@ -14,7 +14,7 @@ msgid "BLUE_STARS"
 msgstr "Estrelas Azuis"
 
 msgid "BROWSE"
-msgstr "Browse"
+msgstr "Procurar"
 
 msgid "CONTACT"
 msgstr "Contacto"
@@ -242,13 +242,13 @@ msgid "SPOTIFY"
 msgstr "Spotify"
 
 msgid "STARS"
-msgstr "Stars"
+msgstr "Estrelas"
 
 msgid "SUDOMEMO"
 msgstr "Sudomemo"
 
 msgid "THIS_FLIPNOTE_IS_SPINOFF_OF"
-msgstr "This Flipnote is a spin-off of"
+msgstr "Este Flipnote é um spin-off de"
 
 msgid "TOTAL_FLIPNOTES"
 msgstr "Flipnotes Totais"

--- a/pt_PT/LC_MESSAGES/channelDetails.po
+++ b/pt_PT/LC_MESSAGES/channelDetails.po
@@ -13,7 +13,7 @@ msgid "CHANNEL_INFORMATION"
 msgstr "Informação do Canal"
 
 msgid "CHANNEL_LOCKED"
-msgstr "This channel is locked."
+msgstr "Este canal está trancado."
 
 msgid "CHANNEL_NAME"
 msgstr "Nome do Canal"

--- a/pt_PT/LC_MESSAGES/chatrooms.po
+++ b/pt_PT/LC_MESSAGES/chatrooms.po
@@ -49,61 +49,61 @@ msgid "PAGE_FORMAT"
 msgstr "Página %d"
 
 msgid "ROOM_NAME_anime_chat"
-msgstr "Anime Chat"
+msgstr "Sala Chat Anime"
 
 msgid "ROOM_NAME_blue_chat"
-msgstr "Blue Chat"
+msgstr "Sala Chat Azul"
 
 msgid "ROOM_NAME_drawings"
-msgstr "Drawings"
+msgstr "Desenhos"
 
 msgid "ROOM_NAME_french_chat"
-msgstr "French Chat"
+msgstr "Sala Chat Francesa"
 
 msgid "ROOM_NAME_friend_code_exchange"
-msgstr "Friend Code Exchange"
+msgstr "Troca de Cód. Amigo"
 
 msgid "ROOM_NAME_german_chat"
-msgstr "German Chat"
+msgstr "Sala Chat Alemã"
 
 msgid "ROOM_NAME_greek_chat"
-msgstr "Greek Chat"
+msgstr "Sala Chat Grega"
 
 msgid "ROOM_NAME_green_chat"
-msgstr "Green Chat"
+msgstr "Sala Chat Verde"
 
 msgid "ROOM_NAME_japanese_chat"
-msgstr "Japanese Chat"
+msgstr "Sala Chat Japonesa"
 
 msgid "ROOM_NAME_kirby_chat"
-msgstr "Kirby Chat"
+msgstr "Sala Chat Kirby"
 
 msgid "ROOM_NAME_mlp_chat"
-msgstr "MLP Chat"
+msgstr "Sala Chat MLP"
 
 msgid "ROOM_NAME_music_chat"
-msgstr "Music Chat"
+msgstr "Sala Chat Música"
 
 msgid "ROOM_NAME_orange_chat"
-msgstr "Orange Chat"
+msgstr "Sala Chat Laranja"
 
 msgid "ROOM_NAME_pokemon_chat"
-msgstr "Pokémon Chat"
+msgstr "Sala Chat Pokémon"
 
 msgid "ROOM_NAME_red_chat"
-msgstr "Red Chat"
+msgstr "Sala Chat Vermelha"
 
 msgid "ROOM_NAME_roleplay_chat_1"
-msgstr "Roleplay Chat 1"
+msgstr "Sala Chat Roleplay 1"
 
 msgid "ROOM_NAME_roleplay_chat_2"
-msgstr "Roleplay Chat 2"
+msgstr "Sala Chat Roleplay 2"
 
 msgid "ROOM_NAME_spanish_chat"
-msgstr "Spanish Chat"
+msgstr "Sala Chat Espanhola"
 
 msgid "ROOM_NAME_stick_figure_chat"
-msgstr "Stick Figure Chat"
+msgstr "Sala Chat Stick Figure"
 
 msgid "ROOM_NAME_wolf_chat"
-msgstr "Wolf Chat"
+msgstr "Sala Chat Lobos"

--- a/pt_PT/LC_MESSAGES/creatorsRoom.po
+++ b/pt_PT/LC_MESSAGES/creatorsRoom.po
@@ -31,7 +31,7 @@ msgid "ADMIN_USER_STATUS"
 msgstr "Estado do Utilizador"
 
 msgid "BLOCK"
-msgstr "Block"
+msgstr "Bloquear"
 
 msgid "BLOCKED_USERS"
 msgstr "Utilizadores Bloqueados"
@@ -40,10 +40,10 @@ msgid "BLOCK_COMMENTS_HEADER"
 msgstr "Bloquear Comentárioss"
 
 msgid "BLOCK_COMMENTS_LINK"
-msgstr "Bloquear"
+msgstr "Bloquear comentário(s)"
 
 msgid "BLOCK_USER"
-msgstr "Block user"
+msgstr "Bloquear utiliz."
 
 msgid "CAN_DRAW_TICKET_SUBTEXT"
 msgstr "Podes sortear um bilhete normal! És capaz de ganhar um prémio."
@@ -218,10 +218,10 @@ msgid "TICKET_SECTION"
 msgstr "Bilhetes"
 
 msgid "UNBLOCK"
-msgstr "Unblock"
+msgstr "Desbloquear"
 
 msgid "UNBLOCK_USER"
-msgstr "Unblock user"
+msgstr "Desbloquear utilizador"
 
 msgid "USABILITY_NOT_USABLE"
 msgstr "Não Usável"
@@ -248,4 +248,4 @@ msgid "WATCH_HISTORY"
 msgstr "Histórico de Visual."
 
 msgid "YOU_HAVE_BLOCKED_THIS_USER"
-msgstr "You have blocked this user."
+msgstr "Tu bloqueaste este utilizador."

--- a/pt_PT/LC_MESSAGES/discordbot.po
+++ b/pt_PT/LC_MESSAGES/discordbot.po
@@ -13,7 +13,7 @@ msgid "BOOST_TICKET_SUCCESS"
 msgstr "%s recebeu um Bilhete Nitro Booster, isto pode ser trocado por um mês de Sudomemo Plus e um troféu especial. Hurra!"
 
 msgid "CONSIDER_X_CHANNEL_FOR_THIS"
-msgstr "Consider using %s for this"
+msgstr "Considere a usar o canal %s para isto"
 
 # Account linking
 msgid "DISCORD_LINKING_GET_STARTED"

--- a/pt_PT/LC_MESSAGES/inventory.po
+++ b/pt_PT/LC_MESSAGES/inventory.po
@@ -25,7 +25,7 @@ msgid "REDEEM"
 msgstr "Trocar"
 
 msgid "THEMES"
-msgstr "Themes"
+msgstr "Temas"
 
 msgid "TICKETS"
 msgstr "Bilhetes"

--- a/pt_PT/LC_MESSAGES/login.po
+++ b/pt_PT/LC_MESSAGES/login.po
@@ -233,10 +233,10 @@ msgid "SEEK_LOGIN_HELP_IN_DISCORD_FORMAT"
 msgstr "Se precisas de ajuda a te ligar, não tenhas medo de perguntar no nosso Servidor Discord! Podes juntar-te no link %s."
 
 msgid "SIGNUP_AGE_GATE_ERROR"
-msgstr "You'll need to be 13 or older to create a new Sudomemo account."
+msgstr "Precisas de ter 13 anos ou mais velho para criar uma conta Sudomemo."
 
 msgid "SIGNUP_AGE_GATE_ERROR_FIX"
-msgstr "If you've received this message in error, you can update your birthday by tapping the orange wrench icon in the top right of Flipnote Studio's main menu."
+msgstr "Se recebeste esta mensagem por engano, podes actualizar a tua data de nascimento ao tocar no ícone chave inglesa laranja no menu principal do Flipnote Studio."
 
 msgid "SORRY_NO_LOGIN"
 msgstr "Desculpa, mas não podemos conseguir fazer o login!"

--- a/pt_PT/LC_MESSAGES/ratelimits.po
+++ b/pt_PT/LC_MESSAGES/ratelimits.po
@@ -4,10 +4,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "HOURLY_CHAT_MESSAGE_LIMIT_REACHED"
-msgstr "You may only send %s chat messages per hour."
+msgstr "Só podes enviar %s mensagens de chat por hora."
 
 msgid "HOURLY_COMMENT_LIMIT_REACHED"
-msgstr "You may only post %s comments per hour."
+msgstr "Só podes enviar %s comentários por hora."
 
 msgid "HOURLY_FLIPNOTE_LIMIT_REACHED"
-msgstr "You may only upload %s Flipnotes per hour."
+msgstr "Só podes fazer upload de %s Flipnotes por hora."

--- a/pt_PT/LC_MESSAGES/theatre.po
+++ b/pt_PT/LC_MESSAGES/theatre.po
@@ -258,7 +258,7 @@ msgid "FANS"
 msgstr "Fãs"
 
 msgid "FAVORITE_OF"
-msgstr "Favorite of"
+msgstr "Favorito de"
 
 msgid "FEATURED"
 msgstr "Em Destaque"
@@ -268,7 +268,7 @@ msgstr "Flipnotes em Destaque"
 
 # usage context: rss or personalized feed
 msgid "FEED"
-msgstr "Feed"
+msgstr "Feed pers."
 
 msgid "FLIPNOTE"
 msgstr "Flipnote"
@@ -664,10 +664,10 @@ msgid "SHARE_ON_WHATSAPP"
 msgstr "Partilhar via WhatsApp"
 
 msgid "SHOW_ON_PROFILE"
-msgstr "Show on profile"
+msgstr "Mostrar no perfil"
 
 msgid "SHOW_YOUTUBE_LINK_ON_MY_PROFILE"
-msgstr "Show a link to my YouTube channel on my Sudomemo profile"
+msgstr "Mostrar um link para o meu canal do YouTube no meu perfil do Sudomemo"
 
 msgid "SIGN_IN"
 msgstr "Fazer Log in"
@@ -683,10 +683,10 @@ msgid "SONG"
 msgstr "Música"
 
 msgid "SONGS"
-msgstr "Songs"
+msgstr "Músicas"
 
 msgid "SONG_ARTISTS"
-msgstr "Song Artists"
+msgstr "Artistas"
 
 msgid "STARS"
 msgstr "Estrelas"
@@ -776,7 +776,7 @@ msgid "USERS_PROFILE_FROM_FLIPNOTE_HATENA"
 msgstr "Perfil do %s do Flipnote Hatena"
 
 msgid "USER_SETTINGS_CHANGE_PASSWORD_EXPLANATION"
-msgstr "You can change the password for your Sudomemo account here:"
+msgstr "Podes mudar a tua palavra-passe da tua conta Sudomemo aqui:"
 
 msgid "USER_SETTINGS_DISCORD_HOW_TO_LINK"
 msgstr "Após ter juntado ao Servidor Discord do Sudomemo, copia e cola isto no chat."
@@ -889,7 +889,7 @@ msgid "WELCOME_BOX_YOU_ARE_ADMIN"
 msgstr "Entraste como Administrador."
 
 msgid "X_USERS"
-msgstr "%d user(s)"
+msgstr "%d utilizador(es)"
 
 msgid "YOUTUBE"
 msgstr "YouTube"


### PR DESCRIPTION
The strings:
- POPULAR - archive.po
- ITEM_NAME_banana - items.po
- TROPHY_NAME_rewind_2021 - trophies.po
- TROPHY_NAME_rewind_2022 - trophies.po
are already translated/don't need translation. (European Portuguese borrows some english words by default when needed. Also the words Popular and Banana are identical in singular for both English and Portuguese.)

May require help on the strings:
- USAGE_draw - discordbot.po
- USAGE_patron_plus - discordbot.po
They are already fully translated, but Sudobot marked them as untranslated.