### PR TITLE
Add new strings for YouTube integration bans.

### DIFF
--- a/cy_GB/LC_MESSAGES/youtube.po
+++ b/cy_GB/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/cy_GB/LC_MESSAGES/youtube.po
+++ b/cy_GB/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/de_DE/LC_MESSAGES/youtube.po
+++ b/de_DE/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Öffentlich"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Nicht gelistet"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/de_DE/LC_MESSAGES/youtube.po
+++ b/de_DE/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "Um dies zu beheben, besuche:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Dein YouTube-Konto ist nicht bestätigt. Einige Features werden nicht komplett funktionieren, wie Video-Thumbnails oder das Posten von Flipnotes mit einer Länge von über 15 Minuten. "
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Geschätzte Spieldauer:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Wiederholungen"
@@ -192,9 +198,3 @@ msgstr "Öffentlich"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Nicht gelistet"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/el_GR/LC_MESSAGES/youtube.po
+++ b/el_GR/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Δημοσιο"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/el_GR/LC_MESSAGES/youtube.po
+++ b/el_GR/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "Για να το διορθωσετε, επισκευτειτε:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Ο λογαριασμος σας στο YouTube δεν ειναι επιβεβαιωμενος. Καποιες δυνατοτητες δεν θα φανουν σωστα, οπως τα thumbnails και Flipnotes μεγαλυτερα των 15 λεπτων."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Πιθανο μηκος βιντεο:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "αριθμος plays"
@@ -192,9 +198,3 @@ msgstr "Δημοσιο"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_AU/LC_MESSAGES/youtube.po
+++ b/en_AU/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_AU/LC_MESSAGES/youtube.po
+++ b/en_AU/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_GB/LC_MESSAGES/youtube.po
+++ b/en_GB/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_GB/LC_MESSAGES/youtube.po
+++ b/en_GB/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_TT/LC_MESSAGES/youtube.po
+++ b/en_TT/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_TT/LC_MESSAGES/youtube.po
+++ b/en_TT/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_US/LC_MESSAGES/youtube.po
+++ b/en_US/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_US/LC_MESSAGES/youtube.po
+++ b/en_US/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_ZA/LC_MESSAGES/youtube.po
+++ b/en_ZA/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_ZA/LC_MESSAGES/youtube.po
+++ b/en_ZA/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/es_ES/LC_MESSAGES/youtube.po
+++ b/es_ES/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "Para arreglar esto, visita:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Tu cuenta de YouTube no está verificada. Ciertas caracteristicas no funcionaran correctamente, tales como miniaturas de vídeos y Flipnotes con una duración mayor a 15 minutos."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Duración estimada del vídeo:"
 
 msgid "YOUTUBE_ID"
 msgstr "ID de YouTube"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Número de reproducciones"
@@ -192,9 +198,3 @@ msgstr "Público"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "No enlistado"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/es_ES/LC_MESSAGES/youtube.po
+++ b/es_ES/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Público"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "No enlistado"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/fr_FR/LC_MESSAGES/youtube.po
+++ b/fr_FR/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Publique"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Non repertoriée"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/fr_FR/LC_MESSAGES/youtube.po
+++ b/fr_FR/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "Pour réparer cela, allez sur :"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Votre compte YouTube n'est pas vérifié. Certaines fonctionnalités ne fonctionneront pas correctement, comme les miniatures des vidéos et les Flipnotes ayant une durée de plus de 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Durée de la vidéo estimée :"
 
 msgid "YOUTUBE_ID"
 msgstr "ID YouTube"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Nombre de lectures"
@@ -192,9 +198,3 @@ msgstr "Publique"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Non repertoriée"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/it_IT/LC_MESSAGES/youtube.po
+++ b/it_IT/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Pubblico"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Non in elenco"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/it_IT/LC_MESSAGES/youtube.po
+++ b/it_IT/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "Per ripararlo, visita:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Il tuo account YouTube non è verificato. Alcune funzioni non saranno disponibili correttamente, come le anteprime dei video e i Flipnote più lunghi di 15 minuti."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Durata del video stimata:"
 
 msgid "YOUTUBE_ID"
 msgstr "ID YouTube"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Numero di riproduzioni"
@@ -192,9 +198,3 @@ msgstr "Pubblico"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Non in elenco"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/ja_JP/LC_MESSAGES/youtube.po
+++ b/ja_JP/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "修正するには、次のURLにアクセスしてください。"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "YouTubeのアカウントが未確認の状態です。サムネイルの設定や15分を超える作品など、確認が必要な機能はご利用になれません。"
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "推定される動画の長さ:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "ループ回数"
@@ -192,9 +198,3 @@ msgstr "公開"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "限定公開"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/ja_JP/LC_MESSAGES/youtube.po
+++ b/ja_JP/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "公開"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "限定公開"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/nl_NL/LC_MESSAGES/youtube.po
+++ b/nl_NL/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/nl_NL/LC_MESSAGES/youtube.po
+++ b/nl_NL/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/pl_PL/LC_MESSAGES/youtube.po
+++ b/pl_PL/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "Aby to naprawic, odwiedz strone:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Twoje konto YouTube nie jest zweryfikowane. Niektóre funkcje nie beda dzialac poprawnie, takie jak miniatury filmów czy Flipnoty trwajace wiecej niz 15 minut."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Przewidywany czas trwania filmu:"
 
 msgid "YOUTUBE_ID"
 msgstr "ID YouTube"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Liczba odtworzeń"
@@ -192,9 +198,3 @@ msgstr "Publiczny"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Niepubliczny"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/pl_PL/LC_MESSAGES/youtube.po
+++ b/pl_PL/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Publiczny"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Niepubliczny"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/pt_PT/LC_MESSAGES/youtube.po
+++ b/pt_PT/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Público"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Não Listado"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/pt_PT/LC_MESSAGES/youtube.po
+++ b/pt_PT/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "Para arranjar este(s) problema(s), visite:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "A tua Conta do YouTube não está verificada. Certas funções podem não funcionar correctamente, tais como thumbnails de vídeo Flipnotes mais compridos que 15 minutos."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Duração de vídeo estimada:"
 
 msgid "YOUTUBE_ID"
 msgstr "ID do YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Nº de loops"
@@ -192,9 +198,3 @@ msgstr "Público"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Não Listado"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/sv_SE/LC_MESSAGES/youtube.po
+++ b/sv_SE/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/sv_SE/LC_MESSAGES/youtube.po
+++ b/sv_SE/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/tr_TR/LC_MESSAGES/youtube.po
+++ b/tr_TR/LC_MESSAGES/youtube.po
@@ -192,3 +192,9 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
+
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/tr_TR/LC_MESSAGES/youtube.po
+++ b/tr_TR/LC_MESSAGES/youtube.po
@@ -114,11 +114,17 @@ msgstr "To fix this, visit:"
 msgid "YOUTUBE_ACCOUNT_VERIFICATION_PROMPT"
 msgstr "Your YouTube account is unverified. Certain features will not function correctly, such as video thumbnails and Flipnotes longer than 15 minutes."
 
+msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "YOUTUBE_ESTIMATED_DURATION"
 msgstr "Estimated video duration:"
 
 msgid "YOUTUBE_ID"
 msgstr "YouTube ID"
+
+msgid "YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account and console have been restricted from using our YouTube integration services."
 
 msgid "YOUTUBE_LOOP_COUNT"
 msgstr "Number of plays"
@@ -192,9 +198,3 @@ msgstr "Public"
 
 msgid "YOUTUBE_VISIBILITY_UNLISTED"
 msgstr "Unlisted"
-
-msgid "YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account and console have been restricted from using our YouTube integration services."
-
-msgid "YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."


### PR DESCRIPTION
This PR adds 2 new strings in `youtube.po`:
- `YOUTUBE_INTEGRATION_BANNED`
- `YOUTUBE_CONTACT_DISCORD_OR_EMAIL_FORMAT`