### PR TITLE
Add missing strings for YouTube integration bans on Theatre

### DIFF
--- a/cy_GB/LC_MESSAGES/theatre.po
+++ b/cy_GB/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/cy_GB/LC_MESSAGES/theatre.po
+++ b/cy_GB/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote by %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/de_DE/LC_MESSAGES/theatre.po
+++ b/de_DE/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Jetzt anschauen:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du bearbeitest gerade dieses Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/de_DE/LC_MESSAGES/theatre.po
+++ b/de_DE/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophäen-Vitrine"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Unbenanntes Flipnote von %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Hochlade-Optionen"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Hochlade-Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Nutzer"
@@ -1055,10 +1062,3 @@ msgstr "Jetzt anschauen:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du bearbeitest gerade dieses Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/el_GR/LC_MESSAGES/theatre.po
+++ b/el_GR/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Δειτε τωρα:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Επεξεργαζεστε αυτο το Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/el_GR/LC_MESSAGES/theatre.po
+++ b/el_GR/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote του χρηστη %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Επιλογες ΔΗμοσιευσης"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Κατασταση Δημοσιευσης"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Δειτε τωρα:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Επεξεργαζεστε αυτο το Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_AU/LC_MESSAGES/theatre.po
+++ b/en_AU/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_AU/LC_MESSAGES/theatre.po
+++ b/en_AU/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote by %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_GB/LC_MESSAGES/theatre.po
+++ b/en_GB/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_GB/LC_MESSAGES/theatre.po
+++ b/en_GB/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote by %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_TT/LC_MESSAGES/theatre.po
+++ b/en_TT/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_TT/LC_MESSAGES/theatre.po
+++ b/en_TT/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote by %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_US/LC_MESSAGES/theatre.po
+++ b/en_US/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_US/LC_MESSAGES/theatre.po
+++ b/en_US/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote by %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/en_ZA/LC_MESSAGES/theatre.po
+++ b/en_ZA/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "U be editing tis Flipnot e:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/en_ZA/LC_MESSAGES/theatre.po
+++ b/en_ZA/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case ;D"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote by %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload fiddling"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload stats"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "U be editing tis Flipnot e:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/es_ES/LC_MESSAGES/theatre.po
+++ b/es_ES/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Vitrina de Trofeos"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Flipnote sin título por %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Opciones de Publicación"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Estado de carga"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Ver ahora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás editando esta Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/es_ES/LC_MESSAGES/theatre.po
+++ b/es_ES/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Ver ahora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás editando esta Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/fr_FR/LC_MESSAGES/theatre.po
+++ b/fr_FR/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Vitrine à trophées"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Flipnote sans titre de %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Options d'envoi"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Statut de l'envoi"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Utilisateurs"
@@ -1055,10 +1062,3 @@ msgstr "Visionner maintenant :"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Vous éditez cette Flipnote :"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/fr_FR/LC_MESSAGES/theatre.po
+++ b/fr_FR/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Visionner maintenant :"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Vous éditez cette Flipnote :"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/it_IT/LC_MESSAGES/theatre.po
+++ b/it_IT/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Galleria Trofei"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Flipnote senza titolo di %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Carica opzioni"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Stato del caricamento"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Utenti"
@@ -1055,10 +1062,3 @@ msgstr "Guarda ora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Stai modificando questo Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/it_IT/LC_MESSAGES/theatre.po
+++ b/it_IT/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Guarda ora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Stai modificando questo Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/ja_JP/LC_MESSAGES/theatre.po
+++ b/ja_JP/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "今すぐ見る:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "編集中"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/ja_JP/LC_MESSAGES/theatre.po
+++ b/ja_JP/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "トロフィーケース"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "%sさんの無題の作品"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "アップロードオプション"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "アップロード状態"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "ユーザー"
@@ -1055,10 +1062,3 @@ msgstr "今すぐ見る:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "編集中"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/nl_NL/LC_MESSAGES/theatre.po
+++ b/nl_NL/LC_MESSAGES/theatre.po
@@ -783,12 +783,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Flipnote Zonder Titel door %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1076,10 +1083,3 @@ msgstr "Kijk nu:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Je bent deze Flipnote aan het bewerken:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/nl_NL/LC_MESSAGES/theatre.po
+++ b/nl_NL/LC_MESSAGES/theatre.po
@@ -1076,3 +1076,10 @@ msgstr "Kijk nu:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Je bent deze Flipnote aan het bewerken:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/pl_PL/LC_MESSAGES/theatre.po
+++ b/pl_PL/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Oglądaj teraz:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Edytujesz ten Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/pl_PL/LC_MESSAGES/theatre.po
+++ b/pl_PL/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trofea"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Flipnote baz nazwy stworzony przez %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Opcje przesyłania"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Status przesyłania"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Użytkownicy"
@@ -1055,10 +1062,3 @@ msgstr "Oglądaj teraz:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Edytujesz ten Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/pt_PT/LC_MESSAGES/theatre.po
+++ b/pt_PT/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Ver agora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás a editar este Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/pt_PT/LC_MESSAGES/theatre.po
+++ b/pt_PT/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Armário de Troféus"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Flipnote Sem Título de %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Definições de Upload"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Estado do Upload"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Utilizadores"
@@ -1055,10 +1062,3 @@ msgstr "Ver agora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás a editar este Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/sv_SE/LC_MESSAGES/theatre.po
+++ b/sv_SE/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du redigerar denna Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/sv_SE/LC_MESSAGES/theatre.po
+++ b/sv_SE/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Troféfall"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Odöpt Flipnote av %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du redigerar denna Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/theatre
+++ b/theatre
@@ -1,7 +1,0 @@
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."

--- a/theatre
+++ b/theatre
@@ -1,0 +1,7 @@
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/tr_TR/LC_MESSAGES/theatre.po
+++ b/tr_TR/LC_MESSAGES/theatre.po
@@ -1055,3 +1055,10 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
+
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."

--- a/tr_TR/LC_MESSAGES/theatre.po
+++ b/tr_TR/LC_MESSAGES/theatre.po
@@ -762,12 +762,19 @@ msgstr "Trophy Case"
 msgid "UNTITLED_FLIPNOTE_BY_FORMAT"
 msgstr "Untitled Flipnote by %s"
 
+msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
+msgstr "Please contact us on Discord or via email to %s."
+
 msgid "UPLOAD_OPTIONS"
 msgstr "Upload Options"
 
 # Upload status
 msgid "UPLOAD_STATUS"
 msgstr "Upload Status"
+
+# Upload to YouTube page
+msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
+msgstr "Your account has been restricted from using our YouTube integration services."
 
 msgid "USERS"
 msgstr "Users"
@@ -1055,10 +1062,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# Upload to YouTube page
-msgid "UPLOAD_YOUTUBE_INTEGRATION_BANNED"
-msgstr "Your account has been restricted from using our YouTube integration services."
-
-msgid "UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT"
-msgstr "Please contact us on Discord or via email to %s."


### PR DESCRIPTION
Does what it says on the tin; adds the strings `UPLOAD_YOUTUBE_INTEGRATION_BANNED` and `UPLOAD_CONTACT_DISCORD_OR_EMAIL_FORMAT` to `theatre.po`.

This should have been in the last PR; my bad.