### PR TITLE
Add UI strings for ticket gifting on Theatre

### DIFF
--- a/cy_GB/LC_MESSAGES/theatre.po
+++ b/cy_GB/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/cy_GB/LC_MESSAGES/theatre.po
+++ b/cy_GB/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comments"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/de_DE/LC_MESSAGES/theatre.po
+++ b/de_DE/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Offen"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Kommentare"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Jetzt anschauen:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du bearbeitest gerade dieses Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/de_DE/LC_MESSAGES/theatre.po
+++ b/de_DE/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Jetzt anschauen:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du bearbeitest gerade dieses Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/el_GR/LC_MESSAGES/theatre.po
+++ b/el_GR/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Δειτε τωρα:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Επεξεργαζεστε αυτο το Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/el_GR/LC_MESSAGES/theatre.po
+++ b/el_GR/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Αοιχτο"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Σχολια"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Ειδος"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Δειτε τωρα:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Επεξεργαζεστε αυτο το Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_AU/LC_MESSAGES/theatre.po
+++ b/en_AU/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_AU/LC_MESSAGES/theatre.po
+++ b/en_AU/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comments"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_GB/LC_MESSAGES/theatre.po
+++ b/en_GB/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_GB/LC_MESSAGES/theatre.po
+++ b/en_GB/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comments"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_TT/LC_MESSAGES/theatre.po
+++ b/en_TT/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_TT/LC_MESSAGES/theatre.po
+++ b/en_TT/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comments"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_US/LC_MESSAGES/theatre.po
+++ b/en_US/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_US/LC_MESSAGES/theatre.po
+++ b/en_US/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comments"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_ZA/LC_MESSAGES/theatre.po
+++ b/en_ZA/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "AAAAA"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "U be editing tis Flipnot e:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/en_ZA/LC_MESSAGES/theatre.po
+++ b/en_ZA/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "U be editing tis Flipnot e:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/es_ES/LC_MESSAGES/theatre.po
+++ b/es_ES/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Abierto"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comentarios"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Género"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Ver ahora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás editando esta Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/es_ES/LC_MESSAGES/theatre.po
+++ b/es_ES/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Ver ahora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás editando esta Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/fr_FR/LC_MESSAGES/theatre.po
+++ b/fr_FR/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Visionner maintenant :"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Vous éditez cette Flipnote :"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/fr_FR/LC_MESSAGES/theatre.po
+++ b/fr_FR/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Ouvert"
 msgid "CHRONOLOGICAL"
 msgstr "Chronologique"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Commentaires"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Êtes vous certain de vouloir donner un ticket %s à %s?"
 
@@ -405,6 +414,12 @@ msgstr "Ce ticket est expiré."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "Ceci n'est pas un code de ticket valide. S'il vous plaît, vérifier pour des typographies et réessayer."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "Ce commentaire viole nos Conditions d'Utilisation."
 
@@ -414,8 +429,50 @@ msgstr "Ce ticket ne peux pas être offert."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "Vous ne pouvez donner de ticket à cet utilisateur car il vous a bloqué."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Donner un ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Visionner maintenant :"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Vous éditez cette Flipnote :"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/it_IT/LC_MESSAGES/theatre.po
+++ b/it_IT/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Aperto"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Commenti"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genere"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Guarda ora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Stai modificando questo Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/it_IT/LC_MESSAGES/theatre.po
+++ b/it_IT/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Guarda ora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Stai modificando questo Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/ja_JP/LC_MESSAGES/theatre.po
+++ b/ja_JP/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "今すぐ見る:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "編集中"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/ja_JP/LC_MESSAGES/theatre.po
+++ b/ja_JP/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "公開"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "コメント"
 
@@ -381,6 +384,12 @@ msgstr "うごメモID"
 msgid "GENRE"
 msgstr "ジャンル"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "今すぐ見る:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "編集中"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/nl_NL/LC_MESSAGES/theatre.po
+++ b/nl_NL/LC_MESSAGES/theatre.po
@@ -142,6 +142,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Opmerkingen"
 
@@ -394,6 +397,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -418,6 +427,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -427,8 +442,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1224,60 +1281,3 @@ msgstr "Kijk nu:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Je bent deze Flipnote aan het bewerken:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/nl_NL/LC_MESSAGES/theatre.po
+++ b/nl_NL/LC_MESSAGES/theatre.po
@@ -1224,3 +1224,60 @@ msgstr "Kijk nu:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Je bent deze Flipnote aan het bewerken:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/pl_PL/LC_MESSAGES/theatre.po
+++ b/pl_PL/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Otwarty"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Komentarze"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Gatunek"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Oglądaj teraz:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Edytujesz ten Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/pl_PL/LC_MESSAGES/theatre.po
+++ b/pl_PL/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Oglądaj teraz:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Edytujesz ten Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/pt_PT/LC_MESSAGES/theatre.po
+++ b/pt_PT/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Aberto"
 msgid "CHRONOLOGICAL"
 msgstr "Chronológica"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comentários"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Género"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Ver agora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás a editar este Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/pt_PT/LC_MESSAGES/theatre.po
+++ b/pt_PT/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Ver agora:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Estás a editar este Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/sv_SE/LC_MESSAGES/theatre.po
+++ b/sv_SE/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Öppen"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Kommentarer"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du redigerar denna Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/sv_SE/LC_MESSAGES/theatre.po
+++ b/sv_SE/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "Du redigerar denna Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/tr_TR/LC_MESSAGES/theatre.po
+++ b/tr_TR/LC_MESSAGES/theatre.po
@@ -1192,3 +1192,60 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
+
+msgid "CLOSE"
+msgstr "Close"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"

--- a/tr_TR/LC_MESSAGES/theatre.po
+++ b/tr_TR/LC_MESSAGES/theatre.po
@@ -141,6 +141,9 @@ msgstr "Open"
 msgid "CHRONOLOGICAL"
 msgstr "Chronological"
 
+msgid "CLOSE"
+msgstr "Close"
+
 msgid "COMMENTS"
 msgstr "Comments"
 
@@ -381,6 +384,12 @@ msgstr "FSID"
 msgid "GENRE"
 msgstr "Genre"
 
+msgid "GIFT_ANONYMOUS"
+msgstr "I'd like to remain anonymous."
+
+msgid "GIFT_ANONYMOUS_PREVIEW"
+msgstr "This gift will be sent anonymously."
+
 msgid "GIFT_ARE_YOU_SURE"
 msgstr "Are you sure you want to gift a %s ticket to %s?"
 
@@ -405,6 +414,12 @@ msgstr "This ticket has expired."
 msgid "GIFT_ERROR_INVALID_CODE"
 msgstr "This is not a valid ticket code. Please check for typos and try again."
 
+msgid "GIFT_ERROR_INVALID_FORMAT"
+msgstr "Please enter a valid 12-digit ticket number."
+
+msgid "GIFT_ERROR_PREVIEW"
+msgstr "There was an issue with previewing the ticket. Please try again."
+
 msgid "GIFT_ERROR_PROFANE_COMMENT"
 msgstr "This comment violates our Content Policy."
 
@@ -414,8 +429,50 @@ msgstr "This ticket is not giftable."
 msgid "GIFT_ERROR_RECIPIENT_BLOCKING"
 msgstr "You cannot gift a ticket to this user as they have blocked you."
 
+msgid "GIFT_ERROR_SEND"
+msgstr "There was an issue sending the gift. Please try again."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_INFO_HINT"
+msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_MESSAGE"
+msgstr "Message to %s"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_PREVIEW_FOR"
+msgstr "Preview Gift for %s"
+
+msgid "GIFT_SEND"
+msgstr "Send Gift"
+
+# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
+msgid "GIFT_SHOP_HINT"
+msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_SUCCESS_INFO_1"
+msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
+
+msgid "GIFT_SUCCESS_INFO_2"
+msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"
+
+msgid "GIFT_SUCCESS_TITLE"
+msgstr "Gift Sent Successfully!"
+
 msgid "GIFT_TICKET"
 msgstr "Gift Ticket"
+
+msgid "GIFT_TICKET_CODE"
+msgstr "Ticket Code"
+
+msgid "GIFT_TICKET_PREVIEW"
+msgstr "Ticket Preview"
+
+# %s will be the username of the person the user is gifting to.
+msgid "GIFT_TICKET_TO"
+msgstr "Gift a ticket to %s"
 
 # # はてなID
 msgid "HATENA_ID"
@@ -1192,60 +1249,3 @@ msgstr "Watch now:"
 # Edit Flipnote page
 msgid "YOU_ARE_EDITING_THIS_FLIPNOTE"
 msgstr "You are editing this Flipnote:"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_INFO_HINT"
-msgstr "You can give %s a Sudomemo Ticket! It will be given to them with an optional message from you. You can also choose to remain anonymous."
-
-# %s will be a link to the Sudomemo Shop, with text from this file's "SUDOMEMO_SHOP" string.
-msgid "GIFT_SHOP_HINT"
-msgstr "Need a ticket code? You can get one by purchasing a ticket from the %s."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_TICKET_TO"
-msgstr "Gift a ticket to %s"
-
-msgid "CLOSE"
-msgstr "Close"
-
-msgid "GIFT_TICKET_CODE"
-msgstr "Ticket Code"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_MESSAGE"
-msgstr "Message to %s"
-
-msgid "GIFT_ANONYMOUS"
-msgstr "I'd like to remain anonymous."
-
-msgid "GIFT_ERROR_INVALID_FORMAT"
-msgstr "Please enter a valid 12-digit ticket number."
-
-msgid "GIFT_ERROR_PREVIEW"
-msgstr "There was an issue with previewing the ticket. Please try again."
-
-msgid "GIFT_ERROR_SEND"
-msgstr "There was an issue sending the gift. Please try again."
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_PREVIEW_FOR"
-msgstr "Preview Gift for %s"
-
-msgid "GIFT_TICKET_PREVIEW"
-msgstr "Ticket Preview"
-
-msgid "GIFT_ANONYMOUS_PREVIEW"
-msgstr "This gift will be sent anonymously."
-
-msgid "GIFT_SEND"
-msgstr "Send Gift"
-
-msgid "GIFT_SUCCESS_TITLE"
-msgstr "Gift Sent Successfully!"
-
-# %s will be the username of the person the user is gifting to.
-msgid "GIFT_SUCCESS_INFO_1"
-msgstr "Your gift to %s has been sent successfully. They will be thrilled to receive your thoughtful present!"
-
-msgid "GIFT_SUCCESS_INFO_2"
-msgstr "Thank you for spreading joy and happiness within the Sudomemo community!"


### PR DESCRIPTION
Adds the following new strings to `theatre.po`:

```
"GIFT_INFO_HINT"
"GIFT_SHOP_HINT"
"GIFT_TICKET_TO"
"CLOSE"
"GIFT_TICKET_CODE"
"GIFT_MESSAGE"
"GIFT_ANONYMOUS"
"GIFT_ERROR_INVALID_FORMAT"
"GIFT_ERROR_PREVIEW"
"GIFT_ERROR_SEND"
"GIFT_PREVIEW_FOR"
"GIFT_TICKET_PREVIEW"
"GIFT_ANONYMOUS_PREVIEW"
"GIFT_SEND"
"GIFT_SUCCESS_TITLE"
"GIFT_SUCCESS_INFO_1"
"GIFT_SUCCESS_INFO_2"
```