### PR TITLE
Add ticket/trophy strings for WiiLink partnership

### DIFF
--- a/cy_GB/LC_MESSAGES/tickets.po
+++ b/cy_GB/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Mae gennych chi tocyn!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/cy_GB/LC_MESSAGES/tickets.po
+++ b/cy_GB/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Yn amlwg, dyma'r disgrifiad ar gyfer y tocyn demo."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Tocyn Demo"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Mae gennych chi tocyn!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/cy_GB/LC_MESSAGES/tickets.po
+++ b/cy_GB/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Mae gennych chi tocyn!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/cy_GB/LC_MESSAGES/tickets.po
+++ b/cy_GB/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Thank you for helping localize Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Diolch am ddilyn y Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Llongyfarchiadau ar ennill Pwnc Wythnosol Sudomemo!"
 
@@ -401,6 +404,9 @@ msgstr "Translator Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Tocyn Promo Trydar"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Tocyn Enillydd Pwnc Wythnosol"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Mae gennych chi tocyn!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/cy_GB/LC_MESSAGES/trophies.po
+++ b/cy_GB/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/cy_GB/LC_MESSAGES/trophies.po
+++ b/cy_GB/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Join Sudomemo during our first month of service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Get recognized as a Sudomemo Featured Artist"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
@@ -233,9 +239,3 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/cy_GB/LC_MESSAGES/trophies.po
+++ b/cy_GB/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribute translations to make Sudomemo open to everyone"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submit a winning entry to Sudomemo's Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Translator"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/cy_GB/LC_MESSAGES/trophies.po
+++ b/cy_GB/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/de_DE/LC_MESSAGES/tickets.po
+++ b/de_DE/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Dies ist tatsächlich die Beschreibung des Demo-Tickets."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "Unsere herzlichsten Glückwünsche zum Werden eines Sudomemo-empfohlenen Künstlers!"
 
@@ -307,6 +310,9 @@ msgstr "Demo-Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Empfohlener Künstler-Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du hast ein Ticket erhalten!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/de_DE/LC_MESSAGES/tickets.po
+++ b/de_DE/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du hast ein Ticket erhalten!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/de_DE/LC_MESSAGES/tickets.po
+++ b/de_DE/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Danke, dass du dabei hilfst, Sudomemo für verschiedene Regionen anzupas
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Vielen Dank, dass du Sudomemo auf Twitter folgst!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Glückwunsch zum Gewinn des Wochen-Themas auf Sudomemo!"
 
@@ -401,6 +404,9 @@ msgstr "Übersetzer-Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter-Promo-Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Wochen-Thema-Gewinner-Ticket"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du hast ein Ticket erhalten!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/de_DE/LC_MESSAGES/tickets.po
+++ b/de_DE/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du hast ein Ticket erhalten!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/de_DE/LC_MESSAGES/trophies.po
+++ b/de_DE/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Ist Sudomemo während des ersten Monats beigetreten"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Ist ein offiziell empfohlener Künstler auf Sudomemo"
 
@@ -153,6 +156,9 @@ msgstr "Früher Nutzer"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Empfohlener Künstler"
 
@@ -233,9 +239,3 @@ msgstr "Wochen-Thema-Gewinner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Einladender Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/de_DE/LC_MESSAGES/trophies.po
+++ b/de_DE/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Wochen-Thema-Gewinner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Einladender Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/de_DE/LC_MESSAGES/trophies.po
+++ b/de_DE/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Wochen-Thema-Gewinner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Einladender Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/de_DE/LC_MESSAGES/trophies.po
+++ b/de_DE/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Hat Inhalte zu der allerersten Episode von Sudomemo Radio beigetragen"
 msgid "TROPHY_DESC_translator"
 msgstr "Hat dazu beigetragen, Sudomemo für jeden verständlich zu machen"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Hat schon mal bei Sudomemo's wöchentlichen Thema teilgenommen und gewonnen"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot-Beitragender"
 msgid "TROPHY_NAME_translator"
 msgstr "Übersetzer"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Wochen-Thema-Gewinner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Einladender Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/el_GR/LC_MESSAGES/tickets.po
+++ b/el_GR/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Προφανως, αυτη ειναι η περιγραφη για το 
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "Τα συγχαρητηρια μας που γινατε Προωθημενος Καλλιτεχνης!"
 
@@ -307,6 +310,9 @@ msgstr "Demo Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Λαχνος Προωθημενου Καλλιτεχνη"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Μολις πηρατε λαχνο!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/el_GR/LC_MESSAGES/tickets.po
+++ b/el_GR/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Μολις πηρατε λαχνο!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/el_GR/LC_MESSAGES/tickets.po
+++ b/el_GR/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Σας ευχαριστουμε για την βοηθεια!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Ευχαριστουμε που ακολουθησατε το Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Συγχαρητηρια για την νικη σας στο Sudomemo Weekly Topic!"
 
@@ -401,6 +404,9 @@ msgstr "Λαχνος Μεταφραστη"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promo Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Ticket Νικητη του Weekly Topic"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Μολις πηρατε λαχνο!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/el_GR/LC_MESSAGES/tickets.po
+++ b/el_GR/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Μολις πηρατε λαχνο!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/el_GR/LC_MESSAGES/trophies.po
+++ b/el_GR/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Συνδεθηκε στο Sudomemo τον πρωτο μηνα της υ�
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Αναγνωρισιμος ως Προωθημενος Καλλιτεχνης του Sudomemo"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Προωθημενος Καλλιτεχνης"
 
@@ -233,9 +239,3 @@ msgstr "Νικητης Weekly Topi"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/el_GR/LC_MESSAGES/trophies.po
+++ b/el_GR/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Νικητης Weekly Topi"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/el_GR/LC_MESSAGES/trophies.po
+++ b/el_GR/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Νικητης Weekly Topi"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/el_GR/LC_MESSAGES/trophies.po
+++ b/el_GR/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Παροχη μεταφρασεων για να γινει το Sudomemo ανοιχτο σε ολους"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Νικησε στο Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Μεταφραστης"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Νικητης Weekly Topi"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/en_AU/LC_MESSAGES/tickets.po
+++ b/en_AU/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Obviously, this is the description for the demo ticket."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demo Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/en_AU/LC_MESSAGES/tickets.po
+++ b/en_AU/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/en_AU/LC_MESSAGES/tickets.po
+++ b/en_AU/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/en_AU/LC_MESSAGES/tickets.po
+++ b/en_AU/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Thank you for helping localize Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Thanks for following the Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
 
@@ -401,6 +404,9 @@ msgstr "Translator Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promo Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Weekly Topic Winner Ticket"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/en_AU/LC_MESSAGES/trophies.po
+++ b/en_AU/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/en_AU/LC_MESSAGES/trophies.po
+++ b/en_AU/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Join Sudomemo during our first month of service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Get recognized as a Sudomemo Featured Artist"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
@@ -233,9 +239,3 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/en_AU/LC_MESSAGES/trophies.po
+++ b/en_AU/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribute translations to make Sudomemo open to everyone"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submit a winning entry to Sudomemo's Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Translator"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/en_AU/LC_MESSAGES/trophies.po
+++ b/en_AU/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/en_GB/LC_MESSAGES/tickets.po
+++ b/en_GB/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Obviously, this is the description for the demo ticket."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demo Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/en_GB/LC_MESSAGES/tickets.po
+++ b/en_GB/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/en_GB/LC_MESSAGES/tickets.po
+++ b/en_GB/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/en_GB/LC_MESSAGES/tickets.po
+++ b/en_GB/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Thank you for helping localise Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Thanks for following the Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
 
@@ -401,6 +404,9 @@ msgstr "Translator Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promo Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Weekly Topic Winner Ticket"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/en_GB/LC_MESSAGES/trophies.po
+++ b/en_GB/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/en_GB/LC_MESSAGES/trophies.po
+++ b/en_GB/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Join Sudomemo during our first month of service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Get recognised as a Sudomemo Featured Artist"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
@@ -233,9 +239,3 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/en_GB/LC_MESSAGES/trophies.po
+++ b/en_GB/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribute translations to make Sudomemo open to everyone"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submit a winning entry to Sudomemo's Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Translator"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/en_GB/LC_MESSAGES/trophies.po
+++ b/en_GB/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/en_TT/LC_MESSAGES/tickets.po
+++ b/en_TT/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Obviously, this is the description for the demo ticket."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demo Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/en_TT/LC_MESSAGES/tickets.po
+++ b/en_TT/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/en_TT/LC_MESSAGES/tickets.po
+++ b/en_TT/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/en_TT/LC_MESSAGES/tickets.po
+++ b/en_TT/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Thank you for helping localize Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Thanks for following the Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
 
@@ -401,6 +404,9 @@ msgstr "Translator Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promo Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Weekly Topic Winner Ticket"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/en_TT/LC_MESSAGES/trophies.po
+++ b/en_TT/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/en_TT/LC_MESSAGES/trophies.po
+++ b/en_TT/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Join Sudomemo during our first month of service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Get recognized as a Sudomemo Featured Artist"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
@@ -233,9 +239,3 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/en_TT/LC_MESSAGES/trophies.po
+++ b/en_TT/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribute translations to make Sudomemo open to everyone"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submit a winning entry to Sudomemo's Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Translator"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/en_TT/LC_MESSAGES/trophies.po
+++ b/en_TT/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/en_US/LC_MESSAGES/tickets.po
+++ b/en_US/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Obviously, this is the description for the demo ticket."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demo Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/en_US/LC_MESSAGES/tickets.po
+++ b/en_US/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/en_US/LC_MESSAGES/tickets.po
+++ b/en_US/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/en_US/LC_MESSAGES/tickets.po
+++ b/en_US/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Thank you for helping localize Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Thanks for following the Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
 
@@ -401,6 +404,9 @@ msgstr "Translator Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promo Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Weekly Topic Winner Ticket"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/en_US/LC_MESSAGES/trophies.po
+++ b/en_US/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/en_US/LC_MESSAGES/trophies.po
+++ b/en_US/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Join Sudomemo during our first month of service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Get recognized as a Sudomemo Featured Artist"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
@@ -233,9 +239,3 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/en_US/LC_MESSAGES/trophies.po
+++ b/en_US/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribute translations to make Sudomemo open to everyone"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submit a winning entry to Sudomemo's Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Translator"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/en_US/LC_MESSAGES/trophies.po
+++ b/en_US/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/en_ZA/LC_MESSAGES/tickets.po
+++ b/en_ZA/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "U gotta ticket! Yay!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/en_ZA/LC_MESSAGES/tickets.po
+++ b/en_ZA/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Obviously, this is the description for the demo ticket."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demo Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "U gotta ticket! Yay!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/en_ZA/LC_MESSAGES/tickets.po
+++ b/en_ZA/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Thank you for helping localize Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Thanks for following the Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
 
@@ -401,6 +404,9 @@ msgstr "Translator Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promo Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Weekly Topic Winner Ticket"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "U gotta ticket! Yay!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/en_ZA/LC_MESSAGES/tickets.po
+++ b/en_ZA/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "U gotta ticket! Yay!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/en_ZA/LC_MESSAGES/trophies.po
+++ b/en_ZA/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/en_ZA/LC_MESSAGES/trophies.po
+++ b/en_ZA/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Join Sudomemo during our first month of service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Get recognized as a Sudomemo Featured Artist"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
@@ -233,9 +239,3 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/en_ZA/LC_MESSAGES/trophies.po
+++ b/en_ZA/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribute translations to make Sudomemo open to everyone"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submit a winning entry to Sudomemo's Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Translator"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/en_ZA/LC_MESSAGES/trophies.po
+++ b/en_ZA/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/es_ES/LC_MESSAGES/tickets.po
+++ b/es_ES/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Claramente, esta es la descripción del ticket demostración."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "¡Te damos nuestras cálidas felicitaciones por convertirte en un Artista destacado de Sudomemo!"
 
@@ -307,6 +310,9 @@ msgstr "Ticket demostración"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Ticket de Artista destacado"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "¡Has conseguido un ticket!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/es_ES/LC_MESSAGES/tickets.po
+++ b/es_ES/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "¡Has conseguido un ticket!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/es_ES/LC_MESSAGES/tickets.po
+++ b/es_ES/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "¡Has conseguido un ticket!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/es_ES/LC_MESSAGES/tickets.po
+++ b/es_ES/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "¡Gracias por ayudar a hacer local a Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "¡Gracias por seguir al Twitter de Sudomemo!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "¡Enhorabuena por ganar el Tópico Semanal de Sudomemo!"
 
@@ -401,6 +404,9 @@ msgstr "Ticket de Traductor"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Ticket promoción de Twitter"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Ticket de ganador del Tópico Semanal"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "¡Has conseguido un ticket!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/es_ES/LC_MESSAGES/trophies.po
+++ b/es_ES/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Ganador de la Temática Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/es_ES/LC_MESSAGES/trophies.po
+++ b/es_ES/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Unirse a Sudomemo durante nuestro primer mes de servicio."
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Obten reconocimiento como Artista Destacado en Sudomemo"
 
@@ -153,6 +156,9 @@ msgstr "Miembro Veterano"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Artista Destacado"
 
@@ -233,9 +239,3 @@ msgstr "Ganador de la Temática Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/es_ES/LC_MESSAGES/trophies.po
+++ b/es_ES/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribuye traducciones para hacer de Sudomemo un lugar abierto a todo el mundo."
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Envía una entrada ganadora a la Tematica Semanal de Sudomemo."
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Traductor"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Ganador de la Temática Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/es_ES/LC_MESSAGES/trophies.po
+++ b/es_ES/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Ganador de la Temática Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "Vous avez reçu un cadeau !"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Vous avez obtenu un ticket !"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Évidemment, ceci est la description du ticket démo."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Félicitations pour votre création gagnante à la Flipnote Fight Competition de Sudomemo d'automne 2023 !"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "Nous vous félicitons chaleureusement pour être devenu un artiste en vedette de Sudomemo !"
 
@@ -307,6 +310,9 @@ msgstr "Ticket Démo"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Ticket de lauréat de la F.F.C. de Sudomemo d'automne 2023"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Ticket d'artiste en vedette"
 
@@ -421,9 +427,3 @@ msgstr "Vous avez reçu un cadeau !"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Vous avez obtenu un ticket !"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Merci d'avoir aidé à traduire Sudomemo !"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Merci de suivre Sudomemo sur Twitter !"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Félicitations pour avoir gagné le Weekly Topic (thème hebdomadaire) de Sudomemo !"
 
@@ -401,6 +404,9 @@ msgstr "Ticket de traducteur"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Ticket Promo Twitter"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Ticket Vainqueur du Weekly Topic"
 
@@ -427,9 +433,3 @@ msgstr "Vous avez reçu un cadeau !"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Vous avez obtenu un ticket !"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/fr_FR/LC_MESSAGES/tickets.po
+++ b/fr_FR/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "Vous avez reçu un cadeau !"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Vous avez obtenu un ticket !"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/fr_FR/LC_MESSAGES/trophies.po
+++ b/fr_FR/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Vainqueur du Weekly Topic"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Champion de l'Accueil"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/fr_FR/LC_MESSAGES/trophies.po
+++ b/fr_FR/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Rejoignez Sudomemo pendant notre premier mois de service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "Un des gagnants de la Flipnote Fight Competition de Sudomemo d'automne 2023 !"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Soyez reconnu en tant qu'artiste vedette de Sudomemo"
 
@@ -153,6 +156,9 @@ msgstr "Adopteur de la première heure"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Lauréat de la Flipnote Fight Competition de Sudomemo d'automne 2023"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Artiste en vedette"
 
@@ -233,9 +239,3 @@ msgstr "Vainqueur du Weekly Topic"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Champion de l'Accueil"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/fr_FR/LC_MESSAGES/trophies.po
+++ b/fr_FR/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Vainqueur du Weekly Topic"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Champion de l'Accueil"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/fr_FR/LC_MESSAGES/trophies.po
+++ b/fr_FR/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "A contribué au contenu du tout premier épisode de Radio Sudomemo"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribuez aux traductions pour rendre Sudomemo ouvert à tous"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Soumettez une participation déclarée gagnante du Weekly Topic (thème hebdomadaire) de Sudomemo"
 
@@ -234,14 +237,11 @@ msgstr "Contributeur au pilote de Radio Sudomemo"
 msgid "TROPHY_NAME_translator"
 msgstr "Traducteur"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Vainqueur du Weekly Topic"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Champion de l'Accueil"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/it_IT/LC_MESSAGES/tickets.po
+++ b/it_IT/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Questa è la descrizione del ticket demo, ovviamente."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "Congratulazioni per essere diventato un Artista in primo piano di Sudomemo!"
 
@@ -307,6 +310,9 @@ msgstr "Dimostrazione del Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Ticket Artista in primo piano"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Hai ottenuto un ticket!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/it_IT/LC_MESSAGES/tickets.po
+++ b/it_IT/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Hai ottenuto un ticket!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/it_IT/LC_MESSAGES/tickets.po
+++ b/it_IT/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Grazie per aver tradotto Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Grazie per aver seguito l'account Twitter di Sudomemo!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Congratulazioni per aver vinto il Topic settimanale di Sudomemo!"
 
@@ -401,6 +404,9 @@ msgstr "Ticket Traduttore"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter - Ticket Promozionale"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Ticket per il Vincitore del Topic settimanale"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Hai ottenuto un ticket!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/it_IT/LC_MESSAGES/tickets.po
+++ b/it_IT/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Hai ottenuto un ticket!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/it_IT/LC_MESSAGES/trophies.po
+++ b/it_IT/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Vincitore del Topic settimanale"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Campione d'accoglienza"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/it_IT/LC_MESSAGES/trophies.po
+++ b/it_IT/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Unisciti a Sudomemo durante il nostro primo mese di servizio"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Essere riconosciuto come un Artista in primo piano di Sudomemo"
 
@@ -153,6 +156,9 @@ msgstr "Primo iscritto"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Artista in primo piano"
 
@@ -233,9 +239,3 @@ msgstr "Vincitore del Topic settimanale"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Campione d'accoglienza"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/it_IT/LC_MESSAGES/trophies.po
+++ b/it_IT/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Vincitore del Topic settimanale"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Campione d'accoglienza"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/it_IT/LC_MESSAGES/trophies.po
+++ b/it_IT/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contenuto contribuito al primo episodio di Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribuisci a tradurre Sudomemo e a renderlo accessibile a tutti"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Invia una voce vincente al Topic settimanale di Sudomemo"
 
@@ -234,14 +237,11 @@ msgstr "Contributore Sudomemo Radio Pilot"
 msgid "TROPHY_NAME_translator"
 msgstr "Traduttore"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Vincitore del Topic settimanale"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Campione d'accoglienza"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/ja_JP/LC_MESSAGES/tickets.po
+++ b/ja_JP/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "デモチケットの説明です。"
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "スドメモで注目された作者になったことを心からお祝いします！"
 
@@ -307,6 +310,9 @@ msgstr "デモチケット"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "注目の作者のチケット"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "チケットを手に入れました!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/ja_JP/LC_MESSAGES/tickets.po
+++ b/ja_JP/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "チケットを手に入れました!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/ja_JP/LC_MESSAGES/tickets.po
+++ b/ja_JP/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "チケットを手に入れました!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/ja_JP/LC_MESSAGES/tickets.po
+++ b/ja_JP/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "スドメモの翻訳にご協力いただきありがとうございま
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "スドメモのTwitterをフォローしていただきありがとうございます!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "スドメモ今週のお題への入選おめでとう!"
 
@@ -401,6 +404,9 @@ msgstr "翻訳者チケット"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitterプロモチケット"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "今週のお題入選者チケット"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "チケットを手に入れました!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/ja_JP/LC_MESSAGES/trophies.po
+++ b/ja_JP/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "サービス開始から1か月以内にスドメモに参加する"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "スドメモにおいて注目された作者であると認められる"
 
@@ -153,6 +156,9 @@ msgstr "古参者"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "注目の作者"
 
@@ -233,9 +239,3 @@ msgstr "今週のお題入賞者"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/ja_JP/LC_MESSAGES/trophies.po
+++ b/ja_JP/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "今週のお題入賞者"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/ja_JP/LC_MESSAGES/trophies.po
+++ b/ja_JP/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "今週のお題入賞者"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/ja_JP/LC_MESSAGES/trophies.po
+++ b/ja_JP/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "スドメモラジオの第1回にコンテンツを提供する"
 msgid "TROPHY_DESC_translator"
 msgstr "スドメモをだれでも利用しやすくするための翻訳に協力する"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "スドメモの今週のお題に入賞する"
 
@@ -234,14 +237,11 @@ msgstr "スドメモラジオパイロット貢献者"
 msgid "TROPHY_NAME_translator"
 msgstr "翻訳者"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "今週のお題入賞者"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/nl_NL/LC_MESSAGES/tickets.po
+++ b/nl_NL/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Je hebt een prijskaart!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/nl_NL/LC_MESSAGES/tickets.po
+++ b/nl_NL/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Vanzelfsprekend, dit is de beschrijving voor het demoprijskaartje."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demoprijskaartje"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Je hebt een prijskaart!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/nl_NL/LC_MESSAGES/tickets.po
+++ b/nl_NL/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Bedankt dat je helpt met het lokaliseren van Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Bedankt voor het volgen van de Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Gefeliciteerd met het winnen van de Sudomemo Wekelijkse Onderwerp!"
 
@@ -401,6 +404,9 @@ msgstr "Vertalerticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promotie Prijskaartje"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Wekelijkse Onderwerp Winner Prijskaartje"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Je hebt een prijskaart!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/nl_NL/LC_MESSAGES/tickets.po
+++ b/nl_NL/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Je hebt een prijskaart!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/nl_NL/LC_MESSAGES/trophies.po
+++ b/nl_NL/LC_MESSAGES/trophies.po
@@ -238,3 +238,9 @@ msgstr "Wekelijks Onderwerpwinnaar"
 # There is no good translation as far as I know for this so it's best to leave it untouched.
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/nl_NL/LC_MESSAGES/trophies.po
+++ b/nl_NL/LC_MESSAGES/trophies.po
@@ -45,6 +45,9 @@ msgstr "Neem deel aan Sudomemo in onze eerste maand"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "Een van de winnaars van de Sudomemo Flipnote Fight-wedstrijd herfst 2023!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Wordt erkend als Uitgelichte Kunstenaar"
 
@@ -157,6 +160,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competitie Winnaar"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Uitgelichte Kunstenaars"
 
@@ -238,9 +244,3 @@ msgstr "Wekelijks Onderwerpwinnaar"
 # There is no good translation as far as I know for this so it's best to leave it untouched.
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/nl_NL/LC_MESSAGES/trophies.po
+++ b/nl_NL/LC_MESSAGES/trophies.po
@@ -244,3 +244,9 @@ msgstr "Wekelijks Onderwerpwinnaar"
 # There is no good translation as far as I know for this so it's best to leave it untouched.
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/nl_NL/LC_MESSAGES/trophies.po
+++ b/nl_NL/LC_MESSAGES/trophies.po
@@ -123,6 +123,9 @@ msgstr "Inhoud bijgedragen aan de allereerste aflevering van Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Draag vertalingen bij om Sudomemo open voor iedereen te maken"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Dien een winnende inzending in naar Sudomemo's Wekelijks Onderwerp"
 
@@ -238,15 +241,12 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Vertaler"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Wekelijks Onderwerpwinnaar"
 
 # There is no good translation as far as I know for this so it's best to leave it untouched.
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/pl_PL/LC_MESSAGES/tickets.po
+++ b/pl_PL/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Oczywyscie, to jest opis dla biletu demonstracyjnego."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "Serdecznie gratulujemy zostania Wyróznionym Artysta Sudomemo!"
 
@@ -307,6 +310,9 @@ msgstr "Bilet demonstracyjny"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Bilet Wyróznionego Artysty"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Otrzymano bilet!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/pl_PL/LC_MESSAGES/tickets.po
+++ b/pl_PL/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Otrzymano bilet!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/pl_PL/LC_MESSAGES/tickets.po
+++ b/pl_PL/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Otrzymano bilet!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/pl_PL/LC_MESSAGES/tickets.po
+++ b/pl_PL/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Dziekujemy za pomoc w tlumaczeniu Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Dziekujemy za obserwowanie Sudomemo na Twitterze!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Gratulujemy wygranej w Temacie Tygodnia Sudomemo!"
 
@@ -401,6 +404,9 @@ msgstr "Bilet tlumacza"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Bilet z promocji na Twitterze"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Bilet za wygrana w Temacie Tygodnia"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Otrzymano bilet!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/pl_PL/LC_MESSAGES/trophies.po
+++ b/pl_PL/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Zwyciezca Tematu Tygodnia"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Czempion powitania"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/pl_PL/LC_MESSAGES/trophies.po
+++ b/pl_PL/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Dolacz do Sudomemo podczas pierwszego miesiaca jego istnienia"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Zostań wybrany jako wyrózniony twórca na Sudomemo"
 
@@ -153,6 +156,9 @@ msgstr "Wczesny uzytkownik"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Wyrózniony twórca"
 
@@ -233,9 +239,3 @@ msgstr "Zwyciezca Tematu Tygodnia"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Czempion powitania"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/pl_PL/LC_MESSAGES/trophies.po
+++ b/pl_PL/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Dostarczyl/-a tresci do pierwszego odcinka Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Pomógl/pomogla w tlumaczeniu Sudomemo"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Twój Flipnote wygral Temat Tygodnia"
 
@@ -234,14 +237,11 @@ msgstr "Udzial w odcinku pilotazowym Sudomemo Radio"
 msgid "TROPHY_NAME_translator"
 msgstr "Tlumacz"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Zwyciezca Tematu Tygodnia"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Czempion powitania"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/pl_PL/LC_MESSAGES/trophies.po
+++ b/pl_PL/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Zwyciezca Tematu Tygodnia"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Czempion powitania"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/pt_PT/LC_MESSAGES/tickets.po
+++ b/pt_PT/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Recebeste um bilhete!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/pt_PT/LC_MESSAGES/tickets.po
+++ b/pt_PT/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Obviamente, isto é um bilhete de amostra."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Parabéns a ti, o vencedor da Competição Flipnote Flight do Sudomemo de Outono 2023!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "Nós te damos os nossos parabéns por tornares-te um Artista Destacado no Sudomemo!"
 
@@ -307,6 +310,9 @@ msgstr "Bilhete de Amostra"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Bilhete de Vencedor da C.F.F. Sudomemo Outono 2023"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Bilhete de Artista em Destaque"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Recebeste um bilhete!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/pt_PT/LC_MESSAGES/tickets.po
+++ b/pt_PT/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Obrigado por ajudar a traduzir e localizar o Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Obrigado por seguires a Página do Twitter do Sudomemo!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Parabéns por ganhar uma posição no Tópico Semanal do Sudomemo!"
 
@@ -401,6 +404,9 @@ msgstr "Bilhete de Tradutor"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Bilhete de Promoção do Twitter"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Bilhete de Vencedor o Tópico Semanal"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Recebeste um bilhete!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/pt_PT/LC_MESSAGES/tickets.po
+++ b/pt_PT/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Recebeste um bilhete!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/pt_PT/LC_MESSAGES/trophies.po
+++ b/pt_PT/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Juntaste-te ao Sudomemo durante o nosso primeiro mês de serviço"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "Um dos vencedores da Competição Flipnote Flight do Sudomemo de Outono 2023!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Sê reconhecido como um Artista Destacado no Sudomemo"
 
@@ -153,6 +156,9 @@ msgstr "Primeiro Adoptante"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Vencedor da Competição Flipnote Fight do Sudomemo Outono 2023"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Artista Destacado"
 
@@ -233,9 +239,3 @@ msgstr "Vencedor do Tópico Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Cidadão Acolhedor"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/pt_PT/LC_MESSAGES/trophies.po
+++ b/pt_PT/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Vencedor do Tópico Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Cidadão Acolhedor"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/pt_PT/LC_MESSAGES/trophies.po
+++ b/pt_PT/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contribuíste conteúdo no primeiro episódio do Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribuir traduções para fazer o Sudomemo aberto a todos"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submeter um post vencedor no Tópico Semanal do Sudomemo"
 
@@ -234,14 +237,11 @@ msgstr "Contribuidor Piloto do Sudomemo Radio"
 msgid "TROPHY_NAME_translator"
 msgstr "Tradutor"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Vencedor do Tópico Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Cidadão Acolhedor"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/pt_PT/LC_MESSAGES/trophies.po
+++ b/pt_PT/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Vencedor do Tópico Semanal"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Cidadão Acolhedor"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/sv_SE/LC_MESSAGES/tickets.po
+++ b/sv_SE/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Uppenbarligen är detta beskrivningen för demobiljetten."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demobiljett"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "Du fick en gåva!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du fick en biljett!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/sv_SE/LC_MESSAGES/tickets.po
+++ b/sv_SE/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "Du fick en gåva!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du fick en biljett!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/sv_SE/LC_MESSAGES/tickets.po
+++ b/sv_SE/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Tack för att du lokaliserar Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Tack för att du följer Sudomemo på Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Grattis för att du vann Veckotemat!"
 
@@ -401,6 +404,9 @@ msgstr "Översättar biljett"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promobiljett"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Veckotemats vinnare biljett"
 
@@ -427,9 +433,3 @@ msgstr "Du fick en gåva!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du fick en biljett!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/sv_SE/LC_MESSAGES/tickets.po
+++ b/sv_SE/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "Du fick en gåva!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "Du fick en biljett!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/sv_SE/LC_MESSAGES/trophies.po
+++ b/sv_SE/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Gå med i Sudomemo under vår första månad"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Bli känd som Sudomemo kända Artist"
 
@@ -153,6 +156,9 @@ msgstr "Tidig medlem"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Känd Artist"
 
@@ -233,9 +239,3 @@ msgstr "Veckotemans vinnare"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/sv_SE/LC_MESSAGES/trophies.po
+++ b/sv_SE/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Veckotemans vinnare"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/sv_SE/LC_MESSAGES/trophies.po
+++ b/sv_SE/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Bidra med översättningar för att göra Sudomemo öppen till alla"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Lägg upp en vinnande Flipnote till Sudomemos Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Översättare"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Veckotemans vinnare"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/sv_SE/LC_MESSAGES/trophies.po
+++ b/sv_SE/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Veckotemans vinnare"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"

--- a/tr_TR/LC_MESSAGES/tickets.po
+++ b/tr_TR/LC_MESSAGES/tickets.po
@@ -179,6 +179,9 @@ msgstr "Obviously, this is the description for the demo ticket."
 msgid "TICKET_DESC_fall_2023_ffc_winner_ticket"
 msgstr "Congratulations on your winning entry to the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
 msgid "TICKET_DESC_featured_artist_ticket"
 msgstr "We give our warm congratulations to you for becoming a Sudomemo Featured Artist!"
 
@@ -307,6 +310,9 @@ msgstr "Demo Ticket"
 msgid "TICKET_NAME_fall_2023_ffc_winner_ticket"
 msgstr "Fall 2023 Sudomemo F.F.C. Winner Ticket"
 
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"
+
 msgid "TICKET_NAME_featured_artist_ticket"
 msgstr "Featured Artist Ticket"
 
@@ -421,9 +427,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_fate_2024_winner_ticket"
-msgstr "Congratulations on your winning FATE 2024 submission!"
-
-msgid "TICKET_NAME_fate_2024_winner_ticket"
-msgstr "FATE 2024 Winner Ticket"

--- a/tr_TR/LC_MESSAGES/tickets.po
+++ b/tr_TR/LC_MESSAGES/tickets.po
@@ -421,3 +421,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_fate_2024_winner_ticket"
+msgstr "Congratulations on your winning FATE 2024 submission!"
+
+msgid "TICKET_NAME_fate_2024_winner_ticket"
+msgstr "FATE 2024 Winner Ticket"

--- a/tr_TR/LC_MESSAGES/tickets.po
+++ b/tr_TR/LC_MESSAGES/tickets.po
@@ -427,3 +427,9 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
+
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"

--- a/tr_TR/LC_MESSAGES/tickets.po
+++ b/tr_TR/LC_MESSAGES/tickets.po
@@ -270,6 +270,9 @@ msgstr "Thank you for helping localize Sudomemo!"
 msgid "TICKET_DESC_twitter_promo_ticket"
 msgstr "Thanks for following the Sudomemo Twitter!"
 
+msgid "TICKET_DESC_visited_wii_room_ticket"
+msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
+
 msgid "TICKET_DESC_weekly_topic_winner_ticket"
 msgstr "Congratulations on winning the Sudomemo Weekly Topic!"
 
@@ -401,6 +404,9 @@ msgstr "Translator Ticket"
 msgid "TICKET_NAME_twitter_promo_ticket"
 msgstr "Twitter Promo Ticket"
 
+msgid "TICKET_NAME_visited_wii_room_ticket"
+msgstr "Wii Room Ticket"
+
 msgid "TICKET_NAME_weekly_topic_winner_ticket"
 msgstr "Weekly Topic Winner Ticket"
 
@@ -427,9 +433,3 @@ msgstr "You got a gift!"
 # Ticket delivery
 msgid "YOU_GOT_A_TICKET"
 msgstr "You got a ticket!"
-
-msgid "TICKET_DESC_visited_wii_room_ticket"
-msgstr "Thank you for visiting the Sudomemo Room on Wii Room!"
-
-msgid "TICKET_NAME_visited_wii_room_ticket"
-msgstr "Wii Room Ticket"

--- a/tr_TR/LC_MESSAGES/trophies.po
+++ b/tr_TR/LC_MESSAGES/trophies.po
@@ -233,3 +233,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"

--- a/tr_TR/LC_MESSAGES/trophies.po
+++ b/tr_TR/LC_MESSAGES/trophies.po
@@ -44,6 +44,9 @@ msgstr "Join Sudomemo during our first month of service"
 msgid "TROPHY_DESC_fall_2023_ffc_winner"
 msgstr "One of the winners of the Fall 2023 Sudomemo Flipnote Fight Competition!"
 
+msgid "TROPHY_DESC_fate_2024_winner"
+msgstr "Submitted a winning Flipnote to FATE 2024"
+
 msgid "TROPHY_DESC_featured_artist"
 msgstr "Get recognized as a Sudomemo Featured Artist"
 
@@ -153,6 +156,9 @@ msgstr "Early Adopter"
 msgid "TROPHY_NAME_fall_2023_ffc_winner"
 msgstr "Fall 2023 Sudomemo Flipnote Fight Competition Winner"
 
+msgid "TROPHY_NAME_fate_2024_winner"
+msgstr "FATE 2024 Winner"
+
 msgid "TROPHY_NAME_featured_artist"
 msgstr "Featured Artist"
 
@@ -233,9 +239,3 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_fate_2024_winner"
-msgstr "Submitted a winning Flipnote to FATE 2024"
-
-msgid "TROPHY_NAME_fate_2024_winner"
-msgstr "FATE 2024 Winner"

--- a/tr_TR/LC_MESSAGES/trophies.po
+++ b/tr_TR/LC_MESSAGES/trophies.po
@@ -122,6 +122,9 @@ msgstr "Contributed content to the very first episode of Sudomemo Radio"
 msgid "TROPHY_DESC_translator"
 msgstr "Contribute translations to make Sudomemo open to everyone"
 
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
 msgid "TROPHY_DESC_weekly_topic_winner"
 msgstr "Submit a winning entry to Sudomemo's Weekly Topic"
 
@@ -234,14 +237,11 @@ msgstr "Sudomemo Radio Pilot Contributor"
 msgid "TROPHY_NAME_translator"
 msgstr "Translator"
 
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"
+
 msgid "TROPHY_NAME_weekly_topic_winner"
 msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
-
-msgid "TROPHY_DESC_visited_wii_room"
-msgstr "Visited Sudomemo's Room on Wii Room!"
-
-msgid "TROPHY_NAME_visited_wii_room"
-msgstr "Wii Room Trophy"

--- a/tr_TR/LC_MESSAGES/trophies.po
+++ b/tr_TR/LC_MESSAGES/trophies.po
@@ -239,3 +239,9 @@ msgstr "Weekly Topic Winner"
 
 msgid "TROPHY_NAME_welcoming_champion"
 msgstr "Welcoming Champion"
+
+msgid "TROPHY_DESC_visited_wii_room"
+msgstr "Visited Sudomemo's Room on Wii Room!"
+
+msgid "TROPHY_NAME_visited_wii_room"
+msgstr "Wii Room Trophy"


### PR DESCRIPTION
Adds:

**trophies.po**:
`TROPHY_DESC_visited_wii_room`
`TROPHY_NAME_visited_wii_room`

**tickets.po**:
`TICKET_DESC_visited_wii_room_ticket`
`TICKET_NAME_visited_wii_room_ticket`
